### PR TITLE
Add loose to default_character_set

### DIFF
--- a/controllers/mysql_conf.go
+++ b/controllers/mysql_conf.go
@@ -107,9 +107,9 @@ var (
 			"admin_address": "{{ .AdminAddress }}",
 		},
 		"client": {
-			"port":                  "3306",
-			"socket":                filepath.Join(moco.VarRunPath, "mysqld.sock"),
-			"default_character_set": "utf8mb4",
+			"port":                        "3306",
+			"socket":                      filepath.Join(moco.VarRunPath, "mysqld.sock"),
+			"loose-default_character_set": "utf8mb4",
 		},
 		"mysql": {
 			"auto_rehash":  "OFF",


### PR DESCRIPTION
Mysqlbinlog emits an error and aborts if default_caracter_set is specified because it doesn't interpret it. Adding the loose prefix to default_character_set has mysqlbinlog ignore it, it emits a warning though.

```
$ mysqlbinlog -v /var/lib/mysql/binlog.000002
mysqlbinlog: [ERROR] unknown variable 'default_character_set=utf8mb4'.
```