### PR TITLE
Fix kubectl moco to enable interactive exec.

### DIFF
--- a/cmd/kubectl-moco/cmd/credential.go
+++ b/cmd/kubectl-moco/cmd/credential.go
@@ -56,7 +56,7 @@ password="%s"
 
 func init() {
 	fs := credentialCmd.Flags()
-	fs.StringVarP(&credentialConfig.user, "user", "u", "readonly", "User for login to mysql [`root`, `moco-writable` or `moco-readonly`]")
+	fs.StringVarP(&credentialConfig.user, "user", "u", "moco-readonly", "User for login to mysql [`root`, `moco-writable` or `moco-readonly`]")
 	fs.StringVar(&credentialConfig.format, "format", "plain", "The format of output [`plain` or `myconf`]")
 
 	rootCmd.AddCommand(credentialCmd)

--- a/cmd/kubectl-moco/cmd/credential.go
+++ b/cmd/kubectl-moco/cmd/credential.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cybozu-go/moco"
 	mocov1alpha1 "github.com/cybozu-go/moco/api/v1alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,7 +36,7 @@ func fetchCredential(ctx context.Context, clusterName string) error {
 	if err != nil {
 		return err
 	}
-	password, err := getPassword(ctx, cluster, credentialConfig.user)
+	password, err := getPassword(ctx, moco.UniqueName(cluster), credentialConfig.user)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubectl-moco/cmd/mysql.go
+++ b/cmd/kubectl-moco/cmd/mysql.go
@@ -85,7 +85,7 @@ func runMySQLCommand(ctx context.Context, clusterName string, cmd *cobra.Command
 
 func init() {
 	fs := mysqlCmd.Flags()
-	fs.StringVarP(&mysqlConfig.user, "user", "u", "readonly", "User for login to mysql [`root`, `moco-writable` or `moco-readonly`]")
+	fs.StringVarP(&mysqlConfig.user, "user", "u", "moco-readonly", "User for login to mysql [`root`, `moco-writable` or `moco-readonly`]")
 	fs.IntVar(&mysqlConfig.index, "index", -1, "Index of a target mysql instance")
 	fs.BoolVarP(&mysqlConfig.stdin, "stdin", "i", false, "Pass stdin to the mysql container")
 	fs.BoolVarP(&mysqlConfig.tty, "tty", "t", false, "Stdin is a TTY")

--- a/cmd/kubectl-moco/cmd/root.go
+++ b/cmd/kubectl-moco/cmd/root.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
@@ -22,7 +21,7 @@ import (
 var (
 	kubeConfigFlags *genericclioptions.ConfigFlags
 	kubeClient      client.Client
-	rawClient       *kubernetes.Clientset
+	factory         util.Factory
 	restConfig      *rest.Config
 	namespace       string
 )
@@ -44,7 +43,7 @@ var rootCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		var err error
-		factory := util.NewFactory(util.NewMatchVersionFlags(kubeConfigFlags))
+		factory = util.NewFactory(util.NewMatchVersionFlags(kubeConfigFlags))
 		restConfig, err = factory.ToRESTConfig()
 		if err != nil {
 			return err
@@ -62,11 +61,6 @@ var rootCmd = &cobra.Command{
 		}
 
 		kubeClient, err = client.New(restConfig, client.Options{Scheme: scheme})
-		if err != nil {
-			return err
-		}
-
-		rawClient, err = kubernetes.NewForConfig(restConfig)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR fixes `kubectl-moco` to use the existing `kubectl exec` implements because it has more detailed error handling.