### PR TITLE
Minor fix of kubectl-moco

### DIFF
--- a/cmd/kubectl-moco/cmd/common.go
+++ b/cmd/kubectl-moco/cmd/common.go
@@ -37,12 +37,11 @@ func getPassword(ctx context.Context, clusterUniqueName, user string) (string, e
 	return string(password), nil
 }
 
-func getPodName(ctx context.Context, cluster *mocov1alpha1.MySQLCluster) (string, error) {
-	if mysqlConfig.index >= int(cluster.Spec.Replicas) {
+func getPodName(ctx context.Context, cluster *mocov1alpha1.MySQLCluster, index int) (string, error) {
+	if index >= int(cluster.Spec.Replicas) {
 		return "", errors.New("index should be smaller than replicas")
 	}
-	index := mysqlConfig.index
-	if mysqlConfig.index < 0 {
+	if index < 0 {
 		if cluster.Status.CurrentPrimaryIndex != nil {
 			index = *cluster.Status.CurrentPrimaryIndex
 		} else {

--- a/cmd/kubectl-moco/cmd/credential.go
+++ b/cmd/kubectl-moco/cmd/credential.go
@@ -18,7 +18,7 @@ var credentialConfig struct {
 
 // credentialCmd represents the credential command
 var credentialCmd = &cobra.Command{
-	Use:   "credential",
+	Use:   "credential <CLUSTER_NAME>",
 	Short: "Fetch the credential of a specified user",
 	Long:  "Fetch the credential of a specified user.",
 	Args:  cobra.ExactArgs(1),

--- a/cmd/kubectl-moco/cmd/mysql.go
+++ b/cmd/kubectl-moco/cmd/mysql.go
@@ -51,7 +51,7 @@ func runMySQLCommand(ctx context.Context, clusterName string, cmd *cobra.Command
 		return err
 	}
 
-	podName, err := getPodName(ctx, cluster)
+	podName, err := getPodName(ctx, cluster, mysqlConfig.index)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Stop using global variables that depend on `mysql` subcommands in common functions.
- Fix usage of the `credential` subcommand.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>