### PR TITLE
Delete unused port definition

### DIFF
--- a/cmd/moco-controller/cmd/run.go
+++ b/cmd/moco-controller/cmd/run.go
@@ -44,7 +44,6 @@ func subMain() error {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      config.metricsAddr,
-		Port:                    9443,
 		LeaderElection:          true,
 		LeaderElectionID:        config.leaderElectionID,
 		LeaderElectionNamespace: os.Getenv("POD_NAMESPACE"),


### PR DESCRIPTION
MOCO does not implement webhook, so the `ctrl.Options.Port` option is not necessary.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>