### PR TITLE
Add error messages in RotateLog handler

### DIFF
--- a/agent/rotate.go
+++ b/agent/rotate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cybozu-go/moco/metrics"
 )
 
-// RotateLog rotes log files
+// RotateLog rotates log files
 func (a *Agent) RotateLog(w http.ResponseWriter, r *http.Request) {
 	token := r.URL.Query().Get(moco.AgentTokenParam)
 	if token != a.token {
@@ -28,18 +28,18 @@ func (a *Agent) RotateLog(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		err := os.Rename(errFile, errFile+".0")
 		if err != nil {
+			internalServerError(w, fmt.Errorf("failed to rotate err log file: %w", err))
 			log.Error("failed to rotate err log file", map[string]interface{}{
 				log.FnError: err,
 			})
-			internalServerError(w, fmt.Errorf("failed to rotate err log file: %w", err))
 			metrics.IncrementLogRotationFailureCountMetrics()
 			return
 		}
 	} else if !os.IsNotExist(err) {
+		internalServerError(w, fmt.Errorf("failed to stat err log file: %w", err))
 		log.Error("failed to stat err log file", map[string]interface{}{
 			log.FnError: err,
 		})
-		internalServerError(w, fmt.Errorf("failed to stat err log file: %w", err))
 		metrics.IncrementLogRotationFailureCountMetrics()
 		return
 	}
@@ -49,18 +49,18 @@ func (a *Agent) RotateLog(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		err := os.Rename(slowFile, slowFile+".0")
 		if err != nil {
+			internalServerError(w, fmt.Errorf("failed to rotate slow query log file: %w", err))
 			log.Error("failed to rotate slow query log file", map[string]interface{}{
 				log.FnError: err,
 			})
-			internalServerError(w, fmt.Errorf("failed to rotate slow query log file: %w", err))
 			metrics.IncrementLogRotationFailureCountMetrics()
 			return
 		}
 	} else if !os.IsNotExist(err) {
+		internalServerError(w, fmt.Errorf("failed to stat slow query log file: %w", err))
 		log.Error("failed to stat slow query log file", map[string]interface{}{
 			log.FnError: err,
 		})
-		internalServerError(w, fmt.Errorf("failed to stat slow query log file: %w", err))
 		metrics.IncrementLogRotationFailureCountMetrics()
 		return
 	}
@@ -70,12 +70,22 @@ func (a *Agent) RotateLog(w http.ResponseWriter, r *http.Request) {
 	db, err := a.acc.Get(fmt.Sprintf("%s:%d", podName, a.mysqlAdminPort), moco.MiscUser, a.miscUserPassword)
 	if err != nil {
 		internalServerError(w, fmt.Errorf("failed to get database: %w", err))
+		log.Error("failed to get database", map[string]interface{}{
+			"hostname":  a.mysqlAdminHostname,
+			"port":      a.mysqlAdminPort,
+			log.FnError: err,
+		})
 		metrics.IncrementLogRotationFailureCountMetrics()
 		return
 	}
 
 	if _, err := db.ExecContext(r.Context(), "FLUSH LOCAL ERROR LOGS, SLOW LOGS"); err != nil {
 		internalServerError(w, fmt.Errorf("failed to exec mysql FLUSH: %w", err))
+		log.Error("failed to exec mysql FLUSH", map[string]interface{}{
+			"hostname":  a.mysqlAdminHostname,
+			"port":      a.mysqlAdminPort,
+			log.FnError: err,
+		})
 		metrics.IncrementLogRotationFailureCountMetrics()
 		return
 	}


### PR DESCRIPTION
- Add missing error messages.
- Fix the order of function calls on errors. (`internalServerError()`～`log.Error()`)
   This order is same as other handlers `agent.Health()` and `agent.Clone()`.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>