### PR TITLE
Fix controller log additional field

### DIFF
--- a/controllers/mysql_clustering.go
+++ b/controllers/mysql_clustering.go
@@ -57,7 +57,7 @@ func (r *MySQLClusterReconciler) reconcileClustering(ctx context.Context, log lo
 	}
 
 	for _, o := range op.Operators {
-		log.Info("Run operation", "name", o.Name(), "description", o.Describe())
+		log.Info("run operation", "name", o.Name(), "description", o.Describe())
 		err = o.Run(ctx, infra, cluster, status)
 		if err != nil {
 			condErr := r.setFailureCondition(ctx, cluster, err, nil)
@@ -81,7 +81,7 @@ func (r *MySQLClusterReconciler) reconcileClustering(ctx context.Context, log lo
 	updateMetrics(cluster, op)
 
 	if op.Wait {
-		log.Info("Waiting")
+		log.Info("waiting")
 		return ctrl.Result{RequeueAfter: r.WaitTime}, nil
 	}
 	if len(op.Operators) > 0 {

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -122,7 +122,7 @@ func (r *MySQLClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 			setCondition(&cluster.Status.Conditions, mocov1alpha1.MySQLClusterCondition{
 				Type: mocov1alpha1.ConditionInitialized, Status: corev1.ConditionFalse, Reason: "reconcileInitializeFailed", Message: err.Error()})
 			if errUpdate := r.Status().Update(ctx, cluster); errUpdate != nil {
-				log.Error(err, "failed to status update")
+				log.Error(err, "failed to status update", "status", cluster.Status)
 			}
 			log.Error(err, "failed to initialize MySQLCluster")
 

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -1113,7 +1113,6 @@ func (r *MySQLClusterReconciler) createOrUpdateServices(ctx context.Context, log
 
 func (r *MySQLClusterReconciler) createOrUpdateService(ctx context.Context, cluster *mocov1alpha1.MySQLCluster, svcName string) (bool, controllerutil.OperationResult, error) {
 	isUpdated := false
-
 	svc := &corev1.Service{}
 	svc.SetNamespace(cluster.Namespace)
 	svc.SetName(svcName)

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -99,7 +99,7 @@ func (r *MySQLClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 
 	cluster := &mocov1alpha1.MySQLCluster{}
 	if err := r.Get(ctx, req.NamespacedName, cluster); err != nil {
-		log.Error(err, "unable to fetch MySQLCluster", "name", req.NamespacedName)
+		log.Error(err, "unable to fetch MySQLCluster")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -109,7 +109,7 @@ func (r *MySQLClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 			controllerutil.AddFinalizer(cluster2, mysqlClusterFinalizer)
 			patch := client.MergeFrom(cluster)
 			if err := r.Patch(ctx, cluster2, patch); err != nil {
-				log.Error(err, "failed to add finalizer", "name", cluster.Name)
+				log.Error(err, "failed to add finalizer")
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{Requeue: true}, nil
@@ -162,7 +162,7 @@ func (r *MySQLClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("start finalizing MySQLCluster", "name", cluster.Name)
+	log.Info("start finalizing MySQLCluster")
 	err := r.removePasswordSecretForController(ctx, log, cluster)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -173,7 +173,7 @@ func (r *MySQLClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	controllerutil.RemoveFinalizer(cluster2, mysqlClusterFinalizer)
 	patch := client.MergeFrom(cluster)
 	if err := r.Patch(ctx, cluster2, patch); err != nil {
-		log.Error(err, "failed to remove finalizer", "name", cluster.Name)
+		log.Error(err, "failed to remove finalizer")
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
- Remove duplicate output of MySQLCluster name. The name is set commonly. https://github.com/cybozu-go/moco/blob/54ad80e809100fa01c734dc6edcce7648c1771ac/controllers/mysqlcluster_controller.go#L98
- Output the operation (`CREATE` or `UPDATE`) when reconciling services.
- Lowercase the start of some log messages.
- Output the cluster status when the status could not be updated.