### PR TITLE
Output logs on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,12 +40,34 @@ jobs:
       - run: sudo mkdir /mnt/local-path-provisioner
       - id: run_e2e_test
         run: cd e2e && make KIND_CLUSTER_CONFIG_SUFFIX=-actions test
-      - if: failure() && steps.run_e2e_test.outcome == 'failure'
-        run: |
-          ./e2e/bin/kubectl -n e2e-test-external describe mysqlclusters.moco.cybozu.com
-          ./e2e/bin/kubectl -n e2e-test-external get statefulsets
-          ./e2e/bin/kubectl -n e2e-test-external get pods
-          ./e2e/bin/kubectl -n moco-system logs -lcontrol-plane=moco-controller-manager --tail=-1
-          ./e2e/bin/kubectl -n e2e-test-external logs -lapp.kubernetes.io/name=moco-mysql -c agent --tail=-1
+
+      # Print status and log of each component
+      - run: |
           top -b -n 1
           df -h
+        if: always()
+      - run: ./e2e/bin/kubectl -n moco-system get all
+        if: always()
+      - run: |
+          ./e2e/bin/kubectl -n e2e-test-external describe mysqlclusters.moco.cybozu.com
+          ./e2e/bin/kubectl -n e2e-test-external get all
+        if: always()
+      - run: ./e2e/bin/kubectl -n moco-system logs -lcontrol-plane=moco-controller-manager --tail=-1
+        if: always()
+      - run: ./e2e/bin/kubectl -n e2e-test-external logs -lapp.kubernetes.io/name=moco-mysql -c agent --tail=-1 | grep -w -v well
+        if: always()
+      - name: error log (e2e-test-external, 0)
+        run: |
+          STS_NAME=$(./e2e/bin/kubectl -n e2e-test-external get sts -lapp.kubernetes.io/name=moco-mysql -o jsonpath='{.items[0].metadata.name}')
+          ./e2e/bin/kubectl -n e2e-test-external logs ${STS_NAME}-0 -c err-log --tail=-1
+        if: always()
+      - name: error log (e2e-test-external, 1)
+        run: |
+          STS_NAME=$(./e2e/bin/kubectl -n e2e-test-external get sts -lapp.kubernetes.io/name=moco-mysql -o jsonpath='{.items[0].metadata.name}')
+          ./e2e/bin/kubectl -n e2e-test-external logs ${STS_NAME}-1 -c err-log --tail=-1
+        if: always()
+      - name: error log (e2e-test-external, 2)
+        run: |
+          STS_NAME=$(./e2e/bin/kubectl -n e2e-test-external get sts -lapp.kubernetes.io/name=moco-mysql -o jsonpath='{.items[0].metadata.name}')
+          ./e2e/bin/kubectl -n e2e-test-external logs ${STS_NAME}-2 -c err-log --tail=-1
+        if: always()

--- a/e2e/manifests/mysql_cluster.yaml
+++ b/e2e/manifests/mysql_cluster.yaml
@@ -27,11 +27,9 @@ spec:
             port: 9080
           initialDelaySeconds: 10
           periodSeconds: 5
-      - name: err-filebeat
+      - name: err-log
         image: quay.io/cybozu/filebeat:7.9.2.1
-        args: [
-          "-c", "/etc/filebeat.yml",
-        ]
+        args: ["-c", "/etc/filebeat.yml"]
         volumeMounts:
         - name: err-filebeat-config
           mountPath: /etc/filebeat.yml
@@ -44,11 +42,9 @@ spec:
           readOnly: true
         - name: tmp
           mountPath: /tmp
-      - name: slow-filebeat
+      - name: slow-log
         image: quay.io/cybozu/filebeat:7.9.2.1
-        args: [
-          "-c", "/etc/filebeat.yml",
-        ]
+        args: ["-c", "/etc/filebeat.yml"]
         volumeMounts:
         - name: slow-filebeat-config
           mountPath: /etc/filebeat.yml
@@ -108,7 +104,7 @@ data:
         - /var/log/mysql/mysql.err*
     output.console:
       codec.format:
-        string: '%{[@timestamp]} %{[message]}'
+        string: '%{[message]}'
     logging.files:
       path: /tmp
       name: filebeat
@@ -129,7 +125,7 @@ data:
         - /var/log/mysql/mysql.slow*
     output.console:
       codec.format:
-        string: '%{[@timestamp]} %{[message]}'
+        string: '%{[message]}'
     logging.files:
       path: /tmp
       name: filebeat

--- a/e2e/manifests/mysql_cluster_external.yaml
+++ b/e2e/manifests/mysql_cluster_external.yaml
@@ -27,11 +27,9 @@ spec:
             port: 9080
           initialDelaySeconds: 10
           periodSeconds: 5
-      - name: err-filebeat
+      - name: err-log
         image: quay.io/cybozu/filebeat:7.9.2.1
-        args: [
-          "-c", "/etc/filebeat.yml",
-        ]
+        args: ["-c", "/etc/filebeat.yml"]
         volumeMounts:
         - name: err-filebeat-config
           mountPath: /etc/filebeat.yml
@@ -44,11 +42,9 @@ spec:
           readOnly: true
         - name: tmp
           mountPath: /tmp
-      - name: slow-filebeat
+      - name: slow-log
         image: quay.io/cybozu/filebeat:7.9.2.1
-        args: [
-          "-c", "/etc/filebeat.yml",
-        ]
+        args: ["-c", "/etc/filebeat.yml"]
         volumeMounts:
         - name: slow-filebeat-config
           mountPath: /etc/filebeat.yml
@@ -108,7 +104,7 @@ data:
         - /var/log/mysql/mysql.err*
     output.console:
       codec.format:
-        string: '%{[@timestamp]} %{[message]}'
+        string: '%{[message]}'
     logging.files:
       path: /tmp
       name: filebeat
@@ -129,7 +125,7 @@ data:
         - /var/log/mysql/mysql.slow*
     output.console:
       codec.format:
-        string: '%{[@timestamp]} %{[message]}'
+        string: '%{[message]}'
     logging.files:
       path: /tmp
       name: filebeat


### PR DESCRIPTION
Print logs of the following components.
- moco-controller-manager
- MySQLCluster in `e2e-test-external` ns

In this PR, I cannot print the log of MySQLCluster in`e2e-test` ns.
Because the resource is deleted in the k2e test.
https://github.com/cybozu-go/moco/blob/v0.3.1/e2e/gc_test.go


Signed-off-by: Masayuki Ishii <masa213f@gmail.com>