### PR TITLE
Set logger to mysql library

### DIFF
--- a/cmd/entrypoint/cmd/agent.go
+++ b/cmd/entrypoint/cmd/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cybozu-go/moco/agent"
 	"github.com/cybozu-go/moco/metrics"
 	"github.com/cybozu-go/well"
+	"github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -30,7 +31,11 @@ const (
 type logger struct{}
 
 func (l logger) Println(v ...interface{}) {
-	log.Error(fmt.Sprint(v...), nil)
+	log.Error("[promhttp] "+fmt.Sprint(v...), nil)
+}
+
+func (l logger) Print(v ...interface{}) {
+	log.Error("[mysql] "+fmt.Sprint(v...), nil)
 }
 
 var agentCmd = &cobra.Command{
@@ -72,6 +77,7 @@ var agentCmd = &cobra.Command{
 		mux.HandleFunc("/rotate", agent.RotateLog)
 		mux.HandleFunc("/clone", agent.Clone)
 		mux.HandleFunc("/health", agent.Health)
+		mysql.SetLogger(mysql.Logger(logger{}))
 
 		registry := prometheus.NewRegistry()
 		metrics.RegisterAgentMetrics(registry)

--- a/cmd/entrypoint/cmd/agent.go
+++ b/cmd/entrypoint/cmd/agent.go
@@ -28,14 +28,16 @@ const (
 	readTimeoutFlag       = "read-timeout"
 )
 
-type logger struct{}
+type mysqlLogger struct{}
 
-func (l logger) Println(v ...interface{}) {
-	log.Error("[promhttp] "+fmt.Sprint(v...), nil)
+func (l mysqlLogger) Print(v ...interface{}) {
+	log.Error("[mysql] "+fmt.Sprint(v...), nil)
 }
 
-func (l logger) Print(v ...interface{}) {
-	log.Error("[mysql] "+fmt.Sprint(v...), nil)
+type promhttpLogger struct{}
+
+func (l promhttpLogger) Println(v ...interface{}) {
+	log.Error("[promhttp] "+fmt.Sprint(v...), nil)
 }
 
 var agentCmd = &cobra.Command{
@@ -77,14 +79,14 @@ var agentCmd = &cobra.Command{
 		mux.HandleFunc("/rotate", agent.RotateLog)
 		mux.HandleFunc("/clone", agent.Clone)
 		mux.HandleFunc("/health", agent.Health)
-		mysql.SetLogger(mysql.Logger(logger{}))
+		mysql.SetLogger(mysqlLogger{})
 
 		registry := prometheus.NewRegistry()
 		metrics.RegisterAgentMetrics(registry)
 		mux.Handle("/metrics", promhttp.HandlerFor(
 			registry,
 			promhttp.HandlerOpts{
-				ErrorLog:      logger{},
+				ErrorLog:      promhttpLogger{},
 				ErrorHandling: promhttp.ContinueOnError,
 			},
 		))


### PR DESCRIPTION
Change the log format output from mysql library (`github.com/go-sql-driver/mysql`).

#### Before
```
[mysql] 2020/12/23 05:53:58 packets.go:122: closing bad idle connection: EOF
```

#### After
```
2020-12-23T08:54:18.851335Z mysqlcluster-43f352c5-837f-42ce-8f96-9bc1ceaa3d2b-0 entrypoint error: "[mysql] closing bad idle connection: EOF"
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>