### PR TITLE
Run small test with MySQL 8.0.18 and 8.0.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ env:
 jobs:
   test:
     name: Small Tests
+    strategy:
+      matrix:
+        mysql-version: ["8.0.18", "8.0.20"]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -26,8 +29,8 @@ jobs:
       - run: make setup
         if: steps.cache-tools.outputs.cache-hit != 'true'
       - run: make validate
-      - run: make start-mysqld
-      - run: make test
+      - run: make start-mysqld MYSQL_VERSION=${{ matrix.mysql-version }}
+      - run: make test MYSQL_VERSION=${{ matrix.mysql-version }}
   e2e:
     name: End-to-End Tests
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,11 +8,8 @@ env:
   go-version: 1.13
   cache-version: 1
 jobs:
-  test:
-    name: Small Tests
-    strategy:
-      matrix:
-        mysql-version: ["8.0.18", "8.0.20"]
+  validation:
+    name: Validation
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -29,6 +26,17 @@ jobs:
       - run: make setup
         if: steps.cache-tools.outputs.cache-hit != 'true'
       - run: make validate
+  test:
+    name: Small Tests
+    strategy:
+      matrix:
+        mysql-version: ["8.0.18", "8.0.20"]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.go-version }}
       - run: make start-mysqld MYSQL_VERSION=${{ matrix.mysql-version }}
       - run: make test MYSQL_VERSION=${{ matrix.mysql-version }}
   e2e:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 
 KUBEBUILDER_VERSION := 2.3.1
 CTRLTOOLS_VERSION := 0.4.0
-MYSQL_VERSION := 8.0.21
+MYSQL_VERSION ?= 8.0.20
 
 .PHONY: all
 all: build/moco-controller
@@ -41,24 +41,24 @@ validate: setup
 # Run tests
 .PHONY: test
 test: $(KUBEBUILDER)
-	go test -race -v -coverprofile cover.out ./...
+	go test -ldflags="-X github.com/cybozu-go/moco/test_utils.MySQLVersion=$(MYSQL_VERSION)" -race -v -coverprofile cover.out ./...
 	docker build -t mysql-with-go:latest ./initialize/
 	docker run -v $(PWD):/go/src/github.com/cybozu-go/moco -e GOPATH=/tmp --rm mysql-with-go:latest sh -c "CGO_ENABLED=0 go test -v ./initialize"
 
 .PHONY: start-mysqld
 start-mysqld:
 	if [ "$(shell docker inspect moco-test-mysqld --format='{{ .State.Running }}')" != "true" ]; then \
-		docker run --name moco-test-mysqld --rm -d -p 3306:3306 -e MYSQL_ROOT_PASSWORD=test-password mysql:$(MYSQL_VERSION); \
+		docker run --name moco-test-mysqld --rm -d -p 3306:3306 -e MYSQL_ROOT_PASSWORD=rootpassword mysql:$(MYSQL_VERSION); \
 	fi
 	docker network inspect moco-mysql-net > /dev/null; \
 	if [ $$? -ne 0 ] ; then \
 		docker network create moco-mysql-net; \
 	fi
 	if [ "$(shell docker inspect moco-test-mysqld-donor --format='{{ .State.Running }}')" != "true" ]; then \
-		docker run --name moco-test-mysqld-donor --network=moco-mysql-net --rm -d -p 3307:3307 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=test-password mysql:$(MYSQL_VERSION) --port=3307; \
+		docker run --name moco-test-mysqld-donor --network=moco-mysql-net --rm -d -p 3307:3307 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=rootpassword mysql:$(MYSQL_VERSION) --port=3307; \
 	fi
 	if [ "$(shell docker inspect moco-test-mysqld-replica --format='{{ .State.Running }}')" != "true" ]; then \
-		docker run --name moco-test-mysqld-replica --restart always --network=moco-mysql-net -d -p 3308:3308 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=test-password mysql:$(MYSQL_VERSION) --port=3308; \
+		docker run --name moco-test-mysqld-replica --restart always --network=moco-mysql-net -d -p 3308:3308 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=rootpassword mysql:$(MYSQL_VERSION) --port=3308; \
 	fi
 	echo "127.0.0.1\tmoco-test-mysqld-donor\n127.0.0.1\tmoco-test-mysqld-replica\n" | sudo tee -a /etc/hosts > /dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ validate: setup
 # Run tests
 .PHONY: test
 test: $(KUBEBUILDER)
-	go test -ldflags="-X github.com/cybozu-go/moco/test_utils.MySQLVersion=$(MYSQL_VERSION)" -race -v -coverprofile cover.out ./...
+	MYSQL_VERSION=$(MYSQL_VERSION) go test -race -v -coverprofile cover.out ./...
 	docker build -t mysql-with-go:latest ./initialize/
 	docker run -v $(PWD):/go/src/github.com/cybozu-go/moco -e GOPATH=/tmp --rm mysql-with-go:latest sh -c "CGO_ENABLED=0 go test -v ./initialize"
 

--- a/Makefile
+++ b/Makefile
@@ -48,17 +48,17 @@ test: $(KUBEBUILDER)
 .PHONY: start-mysqld
 start-mysqld:
 	if [ "$(shell docker inspect moco-test-mysqld --format='{{ .State.Running }}')" != "true" ]; then \
-		docker run --name moco-test-mysqld --rm -d -p 3306:3306 -e MYSQL_ROOT_PASSWORD=rootpassword mysql:$(MYSQL_VERSION); \
+		docker run --name moco-test-mysqld --rm -d -p 3306:3306 -e MYSQL_ROOT_PASSWORD=testpassword mysql:$(MYSQL_VERSION); \
 	fi
 	docker network inspect moco-mysql-net > /dev/null; \
 	if [ $$? -ne 0 ] ; then \
 		docker network create moco-mysql-net; \
 	fi
 	if [ "$(shell docker inspect moco-test-mysqld-donor --format='{{ .State.Running }}')" != "true" ]; then \
-		docker run --name moco-test-mysqld-donor --network=moco-mysql-net --rm -d -p 3307:3307 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=rootpassword mysql:$(MYSQL_VERSION) --port=3307; \
+		docker run --name moco-test-mysqld-donor --network=moco-mysql-net --rm -d -p 3307:3307 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=testpassword mysql:$(MYSQL_VERSION) --port=3307; \
 	fi
 	if [ "$(shell docker inspect moco-test-mysqld-replica --format='{{ .State.Running }}')" != "true" ]; then \
-		docker run --name moco-test-mysqld-replica --restart always --network=moco-mysql-net -d -p 3308:3308 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=rootpassword mysql:$(MYSQL_VERSION) --port=3308; \
+		docker run --name moco-test-mysqld-replica --restart always --network=moco-mysql-net -d -p 3308:3308 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=testpassword mysql:$(MYSQL_VERSION) --port=3308; \
 	fi
 	echo "127.0.0.1\tmoco-test-mysqld-donor\n127.0.0.1\tmoco-test-mysqld-replica\n" | sudo tee -a /etc/hosts > /dev/null
 

--- a/accessor/suite_test.go
+++ b/accessor/suite_test.go
@@ -34,7 +34,7 @@ var testEnv *envtest.Environment
 
 const (
 	host      = "localhost"
-	password  = "test-password"
+	password  = "rootpassword"
 	port      = 3306
 	namespace = "test-namespace"
 )

--- a/accessor/suite_test.go
+++ b/accessor/suite_test.go
@@ -34,7 +34,7 @@ var testEnv *envtest.Environment
 
 const (
 	host      = "localhost"
-	password  = "rootpassword"
+	password  = "testpassword"
 	port      = 3306
 	namespace = "test-namespace"
 )

--- a/agent/suite_test.go
+++ b/agent/suite_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	password        = "rootpassword"
+	password        = "testpassword"
 	token           = "dummy-token"
 	metricsPrefix   = "moco_agent_"
 	host            = "localhost"

--- a/agent/suite_test.go
+++ b/agent/suite_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	password        = "test-password"
+	password        = "rootpassword"
 	token           = "dummy-token"
 	metricsPrefix   = "moco_agent_"
 	host            = "localhost"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -37,7 +37,7 @@ func (acc *AccessorMock) Get(addr, user, password string) (*sqlx.DB, error) {
 
 	conf := mysql.NewConfig()
 	conf.User = "root"
-	conf.Passwd = "rootpassword"
+	conf.Passwd = "testpassword"
 	conf.Net = "tcp"
 	conf.Addr = "localhost:3306"
 	conf.Timeout = 3

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -5,22 +5,20 @@ import (
 	"testing"
 	"time"
 
+	mocov1alpha1 "github.com/cybozu-go/moco/api/v1alpha1"
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	mocov1alpha1 "github.com/cybozu-go/moco/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -39,7 +37,7 @@ func (acc *AccessorMock) Get(addr, user, password string) (*sqlx.DB, error) {
 
 	conf := mysql.NewConfig()
 	conf.User = "root"
-	conf.Passwd = "test-password"
+	conf.Passwd = "rootpassword"
 	conf.Net = "tcp"
 	conf.Addr = "localhost:3306"
 	conf.Timeout = 3

--- a/initialize/init_test.go
+++ b/initialize/init_test.go
@@ -18,7 +18,7 @@ import (
 var (
 	initOnceCompletedPath = filepath.Join(moco.MySQLDataPath, "init-once-completed")
 	passwordFilePath      = filepath.Join("/tmp", "moco-root-password")
-	rootPassword          = "root-password"
+	rootPassword          = "testpassword"
 	miscConfPath          = filepath.Join(moco.MySQLDataPath, "misc.cnf")
 	initUser              = "init-user"
 	initPassword          = "init-password"

--- a/operators/configure_intermediate_primary_test.go
+++ b/operators/configure_intermediate_primary_test.go
@@ -45,8 +45,8 @@ var _ = Describe("Configure intermediate primary operator", func() {
 			secret.Data = map[string][]byte{
 				"PRIMARY_HOST":     []byte(mysqldName2),
 				"PRIMARY_PORT":     []byte(strconv.Itoa(mysqldPort2)),
-				"PRIMARY_USER":     []byte(userName),
-				"PRIMARY_PASSWORD": []byte(password),
+				"PRIMARY_USER":     []byte(test_utils.UserName),
+				"PRIMARY_PASSWORD": []byte(test_utils.Password),
 			}
 			return nil
 		})
@@ -68,8 +68,8 @@ var _ = Describe("Configure intermediate primary operator", func() {
 			Index: 0,
 			Options: &accessor.IntermediatePrimaryOptions{
 				PrimaryHost:     mysqldName2,
-				PrimaryUser:     userName,
-				PrimaryPassword: password,
+				PrimaryUser:     test_utils.UserName,
+				PrimaryPassword: test_utils.Password,
 				PrimaryPort:     mysqldPort2,
 			},
 		}
@@ -107,7 +107,7 @@ var _ = Describe("Configure intermediate primary operator", func() {
 
 		db, err := infra.GetDB(0)
 		Expect(err).ShouldNot(HaveOccurred())
-		_, err = db.Exec(`CHANGE MASTER TO MASTER_HOST = ?, MASTER_PORT = ?, MASTER_USER = ?, MASTER_PASSWORD = ?`, mysqldName2, mysqldPort2, userName, password)
+		_, err = db.Exec(`CHANGE MASTER TO MASTER_HOST = ?, MASTER_PORT = ?, MASTER_USER = ?, MASTER_PASSWORD = ?`, mysqldName2, mysqldPort2, test_utils.UserName, test_utils.Password)
 		Expect(err).ShouldNot(HaveOccurred())
 		_, err = db.Exec(`START SLAVE`)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/operators/configure_replication_test.go
+++ b/operators/configure_replication_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Configure replication", func() {
 		secret.Name = namespace + ".test"
 		_, err = ctrl.CreateOrUpdate(ctx, k8sClient, &secret, func() error {
 			secret.Data = map[string][]byte{
-				moco.ReplicationPasswordKey: []byte(password),
+				moco.ReplicationPasswordKey: []byte(test_utils.Password),
 			}
 			return nil
 		})
@@ -64,7 +64,7 @@ var _ = Describe("Configure replication", func() {
 			Index:          0,
 			PrimaryHost:    mysqldName2,
 			PrimaryPort:    mysqldPort2,
-			ReplicatorUser: userName,
+			ReplicatorUser: test_utils.UserName,
 		}
 
 		err := op.Run(ctx, infra, &cluster, nil)

--- a/operators/set_clone_donor_list_test.go
+++ b/operators/set_clone_donor_list_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Set clone donor list", func() {
 			ConnectionTimeout: 3 * time.Second,
 			ReadTimeout:       30 * time.Second,
 		})
-		infra := accessor.NewInfrastructure(k8sClient, acc, password, []string{host + ":" + strconv.Itoa(mysqldPort1), host + ":" + strconv.Itoa(mysqldPort2), host + ":" + strconv.Itoa(mysqldPort3)})
+		infra := accessor.NewInfrastructure(k8sClient, acc, test_utils.Password, []string{test_utils.Host + ":" + strconv.Itoa(mysqldPort1), test_utils.Host + ":" + strconv.Itoa(mysqldPort2), test_utils.Host + ":" + strconv.Itoa(mysqldPort3)})
 
 		host := moco.GetHost(&cluster, *cluster.Status.CurrentPrimaryIndex)
 		hostWithPort := fmt.Sprintf("%s:%d", host, moco.MySQLAdminPort)

--- a/operators/stop_replica_io_thread_test.go
+++ b/operators/stop_replica_io_thread_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Stop replica IO thread", func() {
 		_, infra, cluster := getAccessorInfraCluster()
 		db, err := infra.GetDB(0)
 		Expect(err).ShouldNot(HaveOccurred())
-		_, err = db.Exec(`CHANGE MASTER TO MASTER_HOST = ?, MASTER_PORT = ?, MASTER_USER = ?, MASTER_PASSWORD = ?`, mysqldName2, mysqldPort2, userName, password)
+		_, err = db.Exec(`CHANGE MASTER TO MASTER_HOST = ?, MASTER_PORT = ?, MASTER_USER = ?, MASTER_PASSWORD = ?`, mysqldName2, mysqldPort2, test_utils.UserName, test_utils.Password)
 		Expect(err).ShouldNot(HaveOccurred())
 		_, err = db.Exec(`START SLAVE`)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/operators/suite_test.go
+++ b/operators/suite_test.go
@@ -30,9 +30,6 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 
 const (
-	host            = "localhost"
-	userName        = "root"
-	password        = "test-password"
 	mysqldName1     = "moco-operators-test-mysqld-1"
 	mysqldName2     = "moco-operators-test-mysqld-2"
 	mysqldName3     = "moco-operators-test-mysqld-3"
@@ -42,11 +39,9 @@ const (
 	mysqldServerID1 = 1001
 	mysqldServerID2 = 1002
 	mysqldServerID3 = 1003
-	networkName     = "moco-operators-test-net"
 	systemNamespace = "test-moco-system"
 	namespace       = "test-namespace"
 	token           = "test-token"
-	mySQLVersion    = "8.0.21"
 )
 
 func TestOperators(t *testing.T) {
@@ -110,7 +105,7 @@ func getAccessorInfraCluster() (*accessor.MySQLAccessor, accessor.Infrastructure
 		ConnectionTimeout: 3 * time.Second,
 		ReadTimeout:       30 * time.Second,
 	})
-	inf := accessor.NewInfrastructure(k8sClient, acc, password, []string{host + ":" + strconv.Itoa(mysqldPort1), host + ":" + strconv.Itoa(mysqldPort2)})
+	inf := accessor.NewInfrastructure(k8sClient, acc, test_utils.Password, []string{test_utils.Host + ":" + strconv.Itoa(mysqldPort1), test_utils.Host + ":" + strconv.Itoa(mysqldPort2)})
 	primaryIndex := 0
 	cluster := mocov1alpha1.MySQLCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operators/update_primary_test.go
+++ b/operators/update_primary_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Update primary", func() {
 			ConnectionTimeout: 3 * time.Second,
 			ReadTimeout:       30 * time.Second,
 		})
-		infra := accessor.NewInfrastructure(k8sClient, acc, password, []string{host + ":" + strconv.Itoa(mysqldPort1), host + ":" + strconv.Itoa(mysqldPort2), host + ":" + strconv.Itoa(mysqldPort3)})
+		infra := accessor.NewInfrastructure(k8sClient, acc, test_utils.Password, []string{test_utils.Host + ":" + strconv.Itoa(mysqldPort1), test_utils.Host + ":" + strconv.Itoa(mysqldPort2), test_utils.Host + ":" + strconv.Itoa(mysqldPort3)})
 
 		_, err := ctrl.CreateOrUpdate(ctx, k8sClient, &cluster, func() error {
 			return nil
@@ -67,7 +67,7 @@ var _ = Describe("Update primary", func() {
 
 		db, err := infra.GetDB(0)
 		Expect(err).ShouldNot(HaveOccurred())
-		_, err = db.Exec(`CHANGE MASTER TO MASTER_HOST = ?, MASTER_PORT = ?, MASTER_USER = ?, MASTER_PASSWORD = ?`, mysqldName2, mysqldPort2, userName, password)
+		_, err = db.Exec(`CHANGE MASTER TO MASTER_HOST = ?, MASTER_PORT = ?, MASTER_USER = ?, MASTER_PASSWORD = ?`, mysqldName2, mysqldPort2, test_utils.UserName, test_utils.Password)
 		Expect(err).ShouldNot(HaveOccurred())
 		_, err = db.Exec(`START SLAVE`)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -18,15 +18,14 @@ import (
 )
 
 const (
-	host            = "localhost"
-	userName        = "root"
-	password        = "test-password"
-	networkName     = "moco-test-net"
-	systemNamespace = "test-moco-system"
-	namespace       = "test-namespace"
-	token           = "test-token"
-	mySQLVersion    = "8.0.21"
+	Host        = "localhost"
+	UserName    = "root"
+	Password    = "rootpassword"
+	networkName = "moco-test-net"
 )
+
+// MySQLVersion is the version of MySQL used in small tests. This value is overwritten at runtime.
+var MySQLVersion = "8.0.20"
 
 func run(cmd *well.LogCmd) error {
 	outBuf := new(bytes.Buffer)
@@ -59,8 +58,8 @@ func StartMySQLD(name string, port int, serverID int) error {
 		"--name", name,
 		"-p", fmt.Sprintf("%d:%d", port, port),
 		"-v", filepath.Join(wd, "..", "my.cnf")+":/etc/mysql/conf.d/my.cnf",
-		"-e", "MYSQL_ROOT_PASSWORD="+password,
-		"mysql:"+mySQLVersion,
+		"-e", "MYSQL_ROOT_PASSWORD="+Password,
+		"mysql:"+MySQLVersion,
 		fmt.Sprintf("--port=%d", port),
 		fmt.Sprintf("--server-id=%d", serverID),
 	)
@@ -93,10 +92,10 @@ func RemoveNetwork() error {
 
 func InitializeMySQL(port int) error {
 	conf := mysql.NewConfig()
-	conf.User = userName
-	conf.Passwd = password
+	conf.User = UserName
+	conf.Passwd = Password
 	conf.Net = "tcp"
-	conf.Addr = host + ":" + strconv.Itoa(port)
+	conf.Addr = Host + ":" + strconv.Itoa(port)
 	conf.InterpolateParams = true
 
 	var db *sqlx.DB
@@ -113,7 +112,7 @@ func InitializeMySQL(port int) error {
 	}
 
 	for _, user := range []string{moco.OperatorAdminUser, moco.CloneDonorUser, moco.MiscUser} {
-		_, err = db.Exec("CREATE USER IF NOT EXISTS ?@'%' IDENTIFIED BY ?", user, password)
+		_, err = db.Exec("CREATE USER IF NOT EXISTS ?@'%' IDENTIFIED BY ?", user, Password)
 		if err != nil {
 			return err
 		}
@@ -156,9 +155,9 @@ func InitializeMySQL(port int) error {
 func PrepareTestData(port int) error {
 	conf := mysql.NewConfig()
 	conf.User = "root"
-	conf.Passwd = password
+	conf.Passwd = Password
 	conf.Net = "tcp"
-	conf.Addr = host + ":" + strconv.Itoa(port)
+	conf.Addr = Host + ":" + strconv.Itoa(port)
 	conf.InterpolateParams = true
 
 	db, err := sqlx.Connect("mysql", conf.FormatDSN())
@@ -185,9 +184,9 @@ func PrepareTestData(port int) error {
 func SetValidDonorList(port int, donorHost string, donorPort int) error {
 	conf := mysql.NewConfig()
 	conf.User = "root"
-	conf.Passwd = password
+	conf.Passwd = Password
 	conf.Net = "tcp"
-	conf.Addr = host + ":" + strconv.Itoa(port)
+	conf.Addr = Host + ":" + strconv.Itoa(port)
 	conf.InterpolateParams = true
 
 	db, err := sqlx.Connect("mysql", conf.FormatDSN())
@@ -206,9 +205,9 @@ func SetValidDonorList(port int, donorHost string, donorPort int) error {
 func ResetMaster(port int) error {
 	conf := mysql.NewConfig()
 	conf.User = "root"
-	conf.Passwd = password
+	conf.Passwd = Password
 	conf.Net = "tcp"
-	conf.Addr = host + ":" + strconv.Itoa(port)
+	conf.Addr = Host + ":" + strconv.Itoa(port)
 	conf.InterpolateParams = true
 
 	db, err := sqlx.Connect("mysql", conf.FormatDSN())
@@ -222,9 +221,9 @@ func ResetMaster(port int) error {
 func StartSlaveWithInvalidSettings(port int) error {
 	conf := mysql.NewConfig()
 	conf.User = "root"
-	conf.Passwd = password
+	conf.Passwd = Password
 	conf.Net = "tcp"
-	conf.Addr = host + ":" + strconv.Itoa(port)
+	conf.Addr = Host + ":" + strconv.Itoa(port)
 	conf.InterpolateParams = true
 
 	db, err := sqlx.Connect("mysql", conf.FormatDSN())

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -20,7 +20,7 @@ import (
 const (
 	Host        = "localhost"
 	UserName    = "root"
-	Password    = "rootpassword"
+	Password    = "testpassword"
 	networkName = "moco-test-net"
 )
 

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -24,8 +24,7 @@ const (
 	networkName = "moco-test-net"
 )
 
-// MySQLVersion is the version of MySQL used in small tests. This value is overwritten at runtime.
-var MySQLVersion = "8.0.20"
+var MySQLVersion = os.Getenv("MYSQL_VERSION")
 
 func run(cmd *well.LogCmd) error {
 	outBuf := new(bytes.Buffer)


### PR DESCRIPTION
- Run the small test with MySQL 8.0.18 and 8.0.20
- Remove redundant or unused constants.
- Change the test password: `test-password` -> `testpassword`.
  - Because the GitHub Actions will mask the strings `-password <HOGE>` unexpectedly.
  - If not change the test password, this command is ...
     - `docker run <other param> -e MYSQL_ROOT_PASSWORD=test-password mysql:8.0.18`
  - logged as follows. 😱
     - `docker run <other param> -e MYSQL_ROOT_PASSWORD=test***`

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>