### PR TITLE
test_utils: Make the command output identifiable

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -32,7 +32,7 @@ setup: $(KUBECTL_MOCO) $(KUBECTL) $(KUSTOMIZE)
 test: launch-kind load-image setup
 	$(KUBECTL) config use-context kind-$(KIND_CLUSTER_NAME)
 	$(KUSTOMIZE) build --load_restrictor='none' ./manifests | $(KUBECTL) apply -f -
-	env E2ETEST=1 go test -count=1 -v . -args -ginkgo.progress -ginkgo.v -ginkgo.failFast
+	env E2ETEST=1 go test -count=1 -v -timeout 15m . -args -ginkgo.progress -ginkgo.v -ginkgo.failFast
 
 .PHONY: telepresence
 telepresence:


### PR DESCRIPTION
The output strings of `test_utils` are difficult to read.
I want to be more readable.

##### Before
```
cc654874969102f89cc1c1a5534b7a678849ebcbae5f45752389c69a8537d67f ★ What's this? Σ(゜゜)
2021-01-12T05:48:16.875007Z ubuntu-bionic agent.test info: "well: exec" args="[docker run -d --restart=always --network=moco-test-net --name moco-test-mysqld-donor -p 3307:3307 -v /home/m001282/go/src/github.com/cybozu-go/moco/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=test-password mysql:8.0.21 --port=3307 --server-id=1]" command="/usr/bin/docker" response_time=1.09144722 type="exec"
```

##### After
```
2021-01-12T05:59:40.722844Z ubuntu-bionic agent.test info: "well: exec" args="[docker run -d --restart=always --network=moco-test-net --name moco-test-mysqld-replica -p 3308:3308 -v /home/m001282/go/src/github.com/cybozu-go/moco/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=test-password mysql:8.0.21 --port=3308 --server-id=2]" command="/usr/bin/docker" response_time=1.2752482600000001 type="exec"
[test_utils/stdout] b509e95d03d4ae5f2fdad3dcba63d09fdfe1440c02971f37d6434d8c7bf61fe3
```


Signed-off-by: Masayuki Ishii <masa213f@gmail.com>