### PR TITLE
Use test_utils in accessor tests

### DIFF
--- a/accessor/mysql_accessor_test.go
+++ b/accessor/mysql_accessor_test.go
@@ -5,20 +5,21 @@ import (
 	"time"
 
 	"github.com/cybozu-go/moco"
+	"github.com/cybozu-go/moco/test_utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("MySQL Accessor", func() {
 	It("Should use cache to connect to MySQL instance", func() {
-		addr := host + ":" + strconv.Itoa(port)
+		addr := test_utils.Host + ":" + strconv.Itoa(mysqldPort)
 
 		acc := NewMySQLAccessor(&MySQLAccessorConfig{
 			ConnMaxLifeTime:   30 * time.Minute,
 			ConnectionTimeout: 3 * time.Second,
 			ReadTimeout:       30 * time.Second,
 		})
-		_, err := acc.Get(addr, moco.OperatorAdminUser, password)
+		_, err := acc.Get(addr, moco.OperatorAdminUser, test_utils.OperatorAdminUserPassword)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(acc.dbs).Should(HaveLen(1))
 
@@ -26,18 +27,18 @@ var _ = Describe("MySQL Accessor", func() {
 		Expect(err).Should(HaveOccurred())
 		Expect(acc.dbs).Should(HaveLen(1))
 
-		_, err = acc.Get(addr, moco.OperatorAdminUser, password)
+		_, err = acc.Get(addr, moco.OperatorAdminUser, test_utils.OperatorAdminUserPassword)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(acc.dbs).Should(HaveLen(1))
 
-		_, err = acc.Get(addr, moco.OperatorUser, password)
+		_, err = acc.Get(addr, moco.OperatorUser, test_utils.OperatorUserPassword)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(acc.dbs).Should(HaveLen(2))
 
-		acc.Remove(moco.OperatorAdminUser + ":" + password + "@tcp(" + addr + ")")
+		acc.Remove(moco.OperatorAdminUser + ":" + test_utils.OperatorAdminUserPassword + "@tcp(" + addr + ")")
 		Expect(acc.dbs).Should(HaveLen(1))
 
-		_, err = acc.Get(addr, moco.OperatorAdminUser, password)
+		_, err = acc.Get(addr, moco.OperatorAdminUser, test_utils.OperatorAdminUserPassword)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(acc.dbs).Should(HaveLen(2))
 

--- a/accessor/mysql_status_test.go
+++ b/accessor/mysql_status_test.go
@@ -13,11 +13,6 @@ import (
 var intermediateSecret = "intermediate-primary-secret"
 
 var _ = Describe("Get MySQLCluster status", func() {
-	It("should initialize MySQL for testing", func() {
-		err := initializeMySQL()
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-
 	It("should get MySQL status", func() {
 		_, inf, cluster := getAccessorInfraCluster()
 

--- a/accessor/suite_test.go
+++ b/accessor/suite_test.go
@@ -2,19 +2,15 @@ package accessor
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
-	"github.com/cybozu-go/moco"
 	mocov1alpha1 "github.com/cybozu-go/moco/api/v1alpha1"
-	"github.com/go-sql-driver/mysql"
-	"github.com/jmoiron/sqlx"
+	"github.com/cybozu-go/moco/test_utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,10 +29,10 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 
 const (
-	host      = "localhost"
-	password  = "testpassword"
-	port      = 3306
-	namespace = "test-namespace"
+	namespace      = "test-namespace"
+	mysqldName     = "moco-accessor-test"
+	mysqldPort     = 13306
+	mysqldServerID = 1
 )
 
 func TestAccessors(t *testing.T) {
@@ -68,88 +64,34 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
-	err = initializeMySQL()
+	By("starting MySQL server")
+	test_utils.StopAndRemoveMySQLD(mysqldName)
+	test_utils.RemoveNetwork()
+
+	Eventually(func() error {
+		return test_utils.CreateNetwork()
+	}, 10*time.Second).Should(Succeed())
+	err = test_utils.StartMySQLD(mysqldName, mysqldPort, mysqldServerID)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	By("initializing MySQL server")
+	err = test_utils.InitializeMySQL(mysqldPort)
+	Expect(err).ShouldNot(HaveOccurred())
+	err = test_utils.StartSlaveWithInvalidSettings(mysqldPort)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {
+	By("stopping MySQL server")
+	test_utils.StopAndRemoveMySQLD(mysqldName)
+	test_utils.RemoveNetwork()
+
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })
-
-func initializeMySQL() error {
-	conf := mysql.NewConfig()
-	conf.User = "root"
-	conf.Passwd = password
-	conf.Net = "tcp"
-	conf.Addr = host + ":" + strconv.Itoa(port)
-	conf.InterpolateParams = true
-
-	var db *sqlx.DB
-	var err error
-	for i := 0; i < 10; i++ {
-		db, err = sqlx.Connect("mysql", conf.FormatDSN())
-		if err == nil {
-			break
-		}
-		time.Sleep(time.Second * 3)
-	}
-	if err != nil {
-		return err
-	}
-
-	_, err = db.Exec("CREATE USER IF NOT EXISTS ?@'%' IDENTIFIED BY ?", moco.OperatorAdminUser, password)
-	if err != nil {
-		return err
-	}
-	_, err = db.Exec("GRANT ALL ON *.* TO ?@'%' WITH GRANT OPTION", moco.OperatorAdminUser)
-	if err != nil {
-		return err
-	}
-
-	_, err = db.Exec("CREATE USER IF NOT EXISTS ?@'%' IDENTIFIED BY ?", moco.OperatorUser, password)
-	if err != nil {
-		return err
-	}
-	_, err = db.Exec("GRANT ALL ON *.* TO ?@'%' WITH GRANT OPTION", moco.OperatorUser)
-	if err != nil {
-		return err
-	}
-
-	_, err = db.Exec("INSTALL PLUGIN rpl_semi_sync_master SONAME 'semisync_master.so'")
-	if err != nil {
-		if err.Error() != "Error 1125: Function 'rpl_semi_sync_master' already exists" {
-			return err
-		}
-	}
-	_, err = db.Exec("INSTALL PLUGIN rpl_semi_sync_slave SONAME 'semisync_slave.so'")
-	if err != nil {
-		if err.Error() != "Error 1125: Function 'rpl_semi_sync_slave' already exists" {
-			return err
-		}
-	}
-	_, err = db.Exec("INSTALL PLUGIN clone SONAME 'mysql_clone.so'")
-	if err != nil {
-		if err.Error() != "Error 1125: Function 'clone' already exists" {
-			return err
-		}
-	}
-
-	_, err = db.Exec(`CHANGE MASTER TO MASTER_HOST = ?, MASTER_PORT = ?, MASTER_USER = ?, MASTER_PASSWORD = ?`,
-		"dummy", 3306, "dummy", "dummy")
-	if err != nil {
-		return err
-	}
-	_, err = db.Exec(`CLONE LOCAL DATA DIRECTORY = ?`, "/tmp/"+uuid.NewUUID())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
 
 func getAccessorInfraCluster() (*MySQLAccessor, Infrastructure, mocov1alpha1.MySQLCluster) {
 	acc := NewMySQLAccessor(&MySQLAccessorConfig{
@@ -157,7 +99,7 @@ func getAccessorInfraCluster() (*MySQLAccessor, Infrastructure, mocov1alpha1.MyS
 		ConnectionTimeout: 3 * time.Second,
 		ReadTimeout:       30 * time.Second,
 	})
-	inf := NewInfrastructure(k8sClient, acc, password, []string{fmt.Sprintf("%s:%d", host, 3306)})
+	inf := NewInfrastructure(k8sClient, acc, test_utils.OperatorAdminUserPassword, []string{fmt.Sprintf("%s:%d", test_utils.Host, mysqldPort)})
 	cluster := mocov1alpha1.MySQLCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "test",


### PR DESCRIPTION
Change the accessor test as follows.

- Use a MySQL container launched by `test_utils`.
- Use the appropriate constants for test passwords.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>