### PR TITLE
Refactor agent test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,35 +50,12 @@ start-mysqld:
 	if [ "$(shell docker inspect moco-test-mysqld --format='{{ .State.Running }}')" != "true" ]; then \
 		docker run --name moco-test-mysqld --rm -d -p 3306:3306 -e MYSQL_ROOT_PASSWORD=testpassword mysql:$(MYSQL_VERSION); \
 	fi
-	docker network inspect moco-test-net > /dev/null; \
-	if [ $$? -ne 0 ] ; then \
-		docker network create moco-test-net; \
-	fi
-	if [ "$(shell docker inspect moco-test-mysqld-donor --format='{{ .State.Running }}')" != "true" ]; then \
-		docker run --name moco-test-mysqld-donor --network=moco-test-net --rm -d -p 3307:3307 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=testpassword mysql:$(MYSQL_VERSION) --port=3307; \
-	fi
-	if [ "$(shell docker inspect moco-test-mysqld-replica --format='{{ .State.Running }}')" != "true" ]; then \
-		docker run --name moco-test-mysqld-replica --restart always --network=moco-test-net -d -p 3308:3308 -v $(PWD)/my.cnf:/etc/mysql/conf.d/my.cnf -e MYSQL_ROOT_PASSWORD=testpassword mysql:$(MYSQL_VERSION) --port=3308; \
-	fi
-	echo "127.0.0.1\tmoco-test-mysqld-donor\n127.0.0.1\tmoco-test-mysqld-replica\n" | sudo tee -a /etc/hosts > /dev/null
 
 .PHONY: stop-mysqld
 stop-mysqld:
 	if [ "$(shell docker inspect moco-test-mysqld --format='{{ .State.Running }}')" = "true" ]; then \
 		docker stop moco-test-mysqld; \
 	fi
-	if [ "$(shell docker inspect moco-test-mysqld-donor --format='{{ .State.Running }}')" = "true" ]; then \
-		docker stop moco-test-mysqld-donor; \
-	fi
-	if [ "$(shell docker inspect moco-test-mysqld-replica --format='{{ .State.Running }}')" = "true" ]; then \
-		docker stop moco-test-mysqld-replica; \
-		docker rm moco-test-mysqld-replica; \
-	fi
-	docker network inspect moco-mysql-net > /dev/null; \
-	if [ $$? -eq 0 ] ; then \
-		docker network rm moco-mysql-net; \
-	fi
-	sudo sed -i -e '/moco-test-mysqld-/d' /etc/hosts
 
 # Build moco-controller binary
 build/moco-controller: generate

--- a/agent/clone_test.go
+++ b/agent/clone_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"strconv"
 	"time"
 
@@ -21,6 +23,41 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+type testData struct {
+	primaryHost            string
+	primaryPort            int
+	primaryUser            string
+	primaryPassword        string
+	cloneUser              string
+	clonePassword          string
+	initAfterCloneUser     string
+	initAfterClonePassword string
+}
+
+func writeTestData(data *testData) {
+	writeFile := func(filename, data string) error {
+		return ioutil.WriteFile(path.Join(replicationSourceSecretPath, filename), []byte(data), 0664)
+	}
+
+	var err error
+	err = writeFile("PRIMARY_HOST", data.primaryHost)
+	Expect(err).ShouldNot(HaveOccurred())
+	err = writeFile("PRIMARY_PORT", strconv.Itoa(data.primaryPort))
+	Expect(err).ShouldNot(HaveOccurred())
+	err = writeFile("PRIMARY_USER", data.primaryUser)
+	Expect(err).ShouldNot(HaveOccurred())
+	err = writeFile("PRIMARY_PASSWORD", data.primaryPassword)
+	Expect(err).ShouldNot(HaveOccurred())
+	err = writeFile("CLONE_USER", data.cloneUser)
+	Expect(err).ShouldNot(HaveOccurred())
+	err = writeFile("CLONE_PASSWORD", data.clonePassword)
+	Expect(err).ShouldNot(HaveOccurred())
+	err = writeFile("INIT_AFTER_CLONE_USER", data.initAfterCloneUser)
+	Expect(err).ShouldNot(HaveOccurred())
+	err = writeFile("INIT_AFTER_CLONE_PASSWORD", data.initAfterClonePassword)
+	Expect(err).ShouldNot(HaveOccurred())
+}
 
 func initializeDonorMySQL(isExternal bool) {
 	By("initializing MySQL donor")

--- a/agent/clone_test.go
+++ b/agent/clone_test.go
@@ -50,7 +50,7 @@ func testClone() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("creating agent instance")
-		agent = New(host, token, password, password, replicationSourceSecretPath, "", replicaPort,
+		agent = New(test_utils.Host, token, test_utils.MiscUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, "", replicaPort,
 			&accessor.MySQLAccessorConfig{
 				ConnMaxLifeTime:   30 * time.Minute,
 				ConnectionTimeout: 3 * time.Second,
@@ -179,7 +179,7 @@ func testClone() {
 
 		By("checking result")
 		Eventually(func() error {
-			db, err := agent.acc.Get(host+":"+strconv.Itoa(replicaPort), moco.MiscUser, password)
+			db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), moco.MiscUser, test_utils.MiscUserPassword)
 			if err != nil {
 				return err
 			}
@@ -255,28 +255,28 @@ func testClone() {
 				title:         "invalid donorHostName",
 				donorHost:     "invalid-host",
 				donorPort:     donorPort,
-				cloneUser:     "moco-clone-donor",
-				clonePassword: password,
+				cloneUser:     test_utils.ExternalDonorUser,
+				clonePassword: test_utils.ExternalDonorUserPassword,
 			},
 			{
 				title:         "invalid donorPort",
 				donorHost:     donorHost,
 				donorPort:     10000,
-				cloneUser:     "moco-clone-donor",
-				clonePassword: password,
+				cloneUser:     test_utils.ExternalDonorUser,
+				clonePassword: test_utils.ExternalDonorUserPassword,
 			},
 			{
 				title:         "invalid cloneUser",
 				donorHost:     donorHost,
 				donorPort:     donorPort,
 				cloneUser:     "invalid-user",
-				clonePassword: password,
+				clonePassword: test_utils.ExternalDonorUserPassword,
 			},
 			{
 				title:         "invalid clonePassword",
 				donorHost:     donorHost,
 				donorPort:     donorPort,
-				cloneUser:     "moco-clone-donor",
+				cloneUser:     test_utils.ExternalDonorUser,
 				clonePassword: "invalid-password",
 			},
 		}
@@ -288,8 +288,8 @@ func testClone() {
 				primaryPort:            tt.donorPort,
 				cloneUser:              tt.cloneUser,
 				clonePassword:          tt.clonePassword,
-				initAfterCloneUser:     "init",
-				initAfterClonePassword: "password",
+				initAfterCloneUser:     test_utils.ExternalInitUser,
+				initAfterClonePassword: test_utils.ExternalInitUserPassword,
 			}
 			writeTestData(data)
 
@@ -314,7 +314,7 @@ func testClone() {
 
 			By(fmt.Sprintf("(%s) %s", tt.title, "checking after clone status"))
 			Eventually(func() error {
-				db, err := agent.acc.Get(host+":"+strconv.Itoa(replicaPort), moco.MiscUser, password)
+				db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), moco.MiscUser, test_utils.MiscUserPassword)
 				if err != nil {
 					return err
 				}
@@ -370,10 +370,10 @@ func testClone() {
 		data := &testData{
 			primaryHost:            donorHost,
 			primaryPort:            donorPort,
-			cloneUser:              "moco-clone-donor",
-			clonePassword:          password,
-			initAfterCloneUser:     "init",
-			initAfterClonePassword: "password",
+			cloneUser:              test_utils.ExternalDonorUser,
+			clonePassword:          test_utils.ExternalDonorUserPassword,
+			initAfterCloneUser:     test_utils.ExternalInitUser,
+			initAfterClonePassword: test_utils.ExternalInitUserPassword,
 		}
 		writeTestData(data)
 
@@ -390,7 +390,7 @@ func testClone() {
 		Expect(res).Should(HaveHTTPStatus(http.StatusOK))
 
 		Eventually(func() error {
-			db, err := agent.acc.Get(host+":"+strconv.Itoa(replicaPort), moco.MiscUser, password)
+			db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), moco.MiscUser, test_utils.MiscUserPassword)
 			if err != nil {
 				return err
 			}
@@ -410,7 +410,7 @@ func testClone() {
 		By("getting 500 when secret files doesn't exist")
 		pwd, err := os.Getwd()
 		Expect(err).ShouldNot(HaveOccurred())
-		agent = New(host, token, password, password, pwd, "", replicaPort,
+		agent = New(test_utils.Host, token, test_utils.MiscUserPassword, test_utils.CloneDonorUserPassword, pwd, "", replicaPort,
 			&accessor.MySQLAccessorConfig{
 				ConnMaxLifeTime:   30 * time.Minute,
 				ConnectionTimeout: 3 * time.Second,

--- a/agent/health_test.go
+++ b/agent/health_test.go
@@ -49,7 +49,7 @@ func testHealth() {
 		registry = prometheus.NewRegistry()
 		metrics.RegisterAgentMetrics(registry)
 
-		agent = New(host, token, password, password, replicationSourceSecretPath, "", replicaPort,
+		agent = New(test_utils.Host, token, test_utils.MiscUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, "", replicaPort,
 			&accessor.MySQLAccessorConfig{
 				ConnMaxLifeTime:   30 * time.Minute,
 				ConnectionTimeout: 3 * time.Second,
@@ -99,7 +99,7 @@ func testHealth() {
 
 		By("wating cloning is completed")
 		Eventually(func() error {
-			db, err := agent.acc.Get(host+":"+strconv.Itoa(replicaPort), moco.MiscUser, password)
+			db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), moco.MiscUser, test_utils.MiscUserPassword)
 			if err != nil {
 				return err
 			}

--- a/agent/rotate_test.go
+++ b/agent/rotate_test.go
@@ -27,7 +27,7 @@ func testRotate() {
 		var err error
 		tmpDir, err = ioutil.TempDir("", "moco-test-agent-")
 		Expect(err).ShouldNot(HaveOccurred())
-		agent = New(host, token, password, password, replicationSourceSecretPath, tmpDir, replicaPort,
+		agent = New(test_utils.Host, token, test_utils.MiscUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, tmpDir, replicaPort,
 			&accessor.MySQLAccessorConfig{
 				ConnMaxLifeTime:   30 * time.Minute,
 				ConnectionTimeout: 3 * time.Second,

--- a/agent/suite_test.go
+++ b/agent/suite_test.go
@@ -21,10 +21,8 @@ import (
 )
 
 const (
-	password        = "testpassword"
 	token           = "dummy-token"
 	metricsPrefix   = "moco_agent_"
-	host            = "localhost"
 	donorHost       = "moco-test-mysqld-donor"
 	donorPort       = 3307
 	donorServerID   = 1

--- a/agent/suite_test.go
+++ b/agent/suite_test.go
@@ -2,11 +2,9 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log" // restrictpkg:ignore to suppress mysql client logs.
 	"os"
 	"path"
-	"strconv"
 	"testing"
 	"time"
 
@@ -32,41 +30,6 @@ const (
 )
 
 var replicationSourceSecretPath string
-
-type testData struct {
-	primaryHost            string
-	primaryPort            int
-	primaryUser            string
-	primaryPassword        string
-	cloneUser              string
-	clonePassword          string
-	initAfterCloneUser     string
-	initAfterClonePassword string
-}
-
-func writeTestData(data *testData) {
-	writeFile := func(filename, data string) error {
-		return ioutil.WriteFile(path.Join(replicationSourceSecretPath, filename), []byte(data), 0664)
-	}
-
-	var err error
-	err = writeFile("PRIMARY_HOST", data.primaryHost)
-	Expect(err).ShouldNot(HaveOccurred())
-	err = writeFile("PRIMARY_PORT", strconv.Itoa(data.primaryPort))
-	Expect(err).ShouldNot(HaveOccurred())
-	err = writeFile("PRIMARY_USER", data.primaryUser)
-	Expect(err).ShouldNot(HaveOccurred())
-	err = writeFile("PRIMARY_PASSWORD", data.primaryPassword)
-	Expect(err).ShouldNot(HaveOccurred())
-	err = writeFile("CLONE_USER", data.cloneUser)
-	Expect(err).ShouldNot(HaveOccurred())
-	err = writeFile("CLONE_PASSWORD", data.clonePassword)
-	Expect(err).ShouldNot(HaveOccurred())
-	err = writeFile("INIT_AFTER_CLONE_USER", data.initAfterCloneUser)
-	Expect(err).ShouldNot(HaveOccurred())
-	err = writeFile("INIT_AFTER_CLONE_PASSWORD", data.initAfterClonePassword)
-	Expect(err).ShouldNot(HaveOccurred())
-}
 
 func TestAgent(t *testing.T) {
 	mysql.SetLogger(mysql.Logger(log.New(GinkgoWriter, "[mysql] ", log.Ldate|log.Ltime|log.Lshortfile)))

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -156,14 +156,6 @@ func InitializeMySQL(port int) error {
 			name:     moco.MiscUser,
 			password: MiscUserPassword,
 		},
-		{
-			name:     ExternalDonorUser,
-			password: ExternalDonorUserPassword,
-		},
-		{
-			name:     ExternalInitUser,
-			password: ExternalInitUserPassword,
-		},
 	}
 	for _, user := range users {
 		_, err = db.Exec("CREATE USER IF NOT EXISTS ?@'%' IDENTIFIED BY ?", user.name, user.password)
@@ -188,6 +180,51 @@ func InitializeMySQL(port int) error {
 			return err
 		}
 	}
+	_, err = db.Exec("INSTALL PLUGIN clone SONAME 'mysql_clone.so'")
+	if err != nil {
+		if err.Error() != "Error 1125: Function 'clone' already exists" {
+			return err
+		}
+	}
+
+	_, err = db.Exec("CLONE LOCAL DATA DIRECTORY = ?", "/tmp/"+uuid.NewUUID())
+	if err != nil {
+		return err
+	}
+
+	return ResetMaster(port)
+}
+
+func InitializeMySQLAsExternalDonor(port int) error {
+	db, err := Connect(port, 20)
+	if err != nil {
+		return err
+	}
+
+	users := []struct {
+		name     string
+		password string
+	}{
+		{
+			name:     ExternalDonorUser,
+			password: ExternalDonorUserPassword,
+		},
+		{
+			name:     ExternalInitUser,
+			password: ExternalInitUserPassword,
+		},
+	}
+	for _, user := range users {
+		_, err = db.Exec("CREATE USER IF NOT EXISTS ?@'%' IDENTIFIED BY ?", user.name, user.password)
+		if err != nil {
+			return err
+		}
+		_, err = db.Exec("GRANT ALL ON *.* TO ?@'%' WITH GRANT OPTION", user.name)
+		if err != nil {
+			return err
+		}
+	}
+
 	_, err = db.Exec("INSTALL PLUGIN clone SONAME 'mysql_clone.so'")
 	if err != nil {
 		if err.Error() != "Error 1125: Function 'clone' already exists" {

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -22,6 +22,12 @@ const (
 	RootUser         = "root"
 	RootUserPassword = "testpassword"
 
+	// Dummy user and password for clone from external.
+	ExternalDonorUser         = "external-donor-user"
+	ExternalDonorUserPassword = "externaldonorpassword"
+	ExternalInitUser          = "external-init-user"
+	ExternalInitUserPassword  = "externalinitpassword"
+
 	// Dummy password for MySQL users which are managed by MOCO.
 	OperatorUserPassword      = "testpassword"
 	OperatorAdminUserPassword = "testpassword"
@@ -149,6 +155,14 @@ func InitializeMySQL(port int) error {
 		{
 			name:     moco.MiscUser,
 			password: MiscUserPassword,
+		},
+		{
+			name:     ExternalDonorUser,
+			password: ExternalDonorUserPassword,
+		},
+		{
+			name:     ExternalInitUser,
+			password: ExternalInitUserPassword,
 		},
 	}
 	for _, user := range users {


### PR DESCRIPTION
Change the agent test as follows.

- Use the constants of `test_utils` for test passwords 
- Initialize the primary MySQL as the external donor in the test cases for the clone from external.
- Skip some checks after clone from external.
   - In the current test configuration, the initialization after the clone does not succeed. 
   - I registered another issue to fix the test. https://github.com/cybozu-go/moco/issues/145
- Some minor changes.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>