### PR TITLE
Update Go to 1.15 and Ubuntu to 20.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - 'master'
 env:
-  go-version: 1.13
+  go-version: 1.15
   cache-version: 1
 jobs:
   validation:
     name: Validation
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         mysql-version: ["8.0.18", "8.0.20"]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         mysql-version: ["8.0.18", "8.0.20"]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ env:
 jobs:
   image:
     name: Push Container Image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: docker build . -t moco:dev
@@ -19,7 +19,7 @@ jobs:
   release:
     name: Release on GitHub
     needs: image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the moco-controller binary
-FROM quay.io/cybozu/golang:1.13-bionic as builder
+FROM quay.io/cybozu/golang:1.15-focal as builder
 
 WORKDIR /workspace
 
@@ -9,7 +9,7 @@ COPY ./ .
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o moco-controller ./cmd/moco-controller/main.go
 
-FROM quay.io/cybozu/ubuntu:18.04
+FROM quay.io/cybozu/ubuntu:20.04
 LABEL org.opencontainers.image.source https://github.com/cybozu-go/moco
 
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ setup: custom-checker staticcheck nilerr ineffassign
 .PHONY: custom-checker
 custom-checker:
 	if ! which custom-checker >/dev/null; then \
-		cd /tmp; env GOFLAGS= GO111MODULE=on go install github.com/cybozu/neco-containers/golang/analyzer/cmd/custom-checker; \
+		cd /tmp; env GOFLAGS= GO111MODULE=on go get github.com/cybozu/neco-containers/golang/analyzer/cmd/custom-checker; \
 	fi
 
 .PHONY: staticcheck

--- a/cmd/moco-controller/cmd/root.go
+++ b/cmd/moco-controller/cmd/root.go
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 
 const (
 	defaultInitContainerImage = "quay.io/cybozu/moco-conf-gen:0.3.0"
-	defaultCurlContainerImage = "quay.io/cybozu/ubuntu:18.04"
+	defaultCurlContainerImage = "quay.io/cybozu/ubuntu:20.04"
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/docs/build-mysql.md
+++ b/docs/build-mysql.md
@@ -56,7 +56,7 @@ ENTRYPOINT ["mysqld"]
 This example builds MySQL from source code.
 
 ```
-FROM ubuntu:18.04 AS build
+FROM ubuntu:20.04 AS build
 
 ARG MOCO_VERSION=0.4.0
 ARG MYSQL_VERSION=8.0.20
@@ -78,7 +78,7 @@ RUN apt-get install -y cmake libncurses5-dev libjemalloc-dev libnuma-dev libread
   && make -j $(nproc) \
   && make install
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update \
   && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libncurses5 libjemalloc1 libnuma1 libreadline7 libssl1.1 locales tzdata \

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,5 +1,5 @@
 ARG MYSQL_VERSION
-FROM quay.io/cybozu/golang:1.13-bionic as builder
+FROM quay.io/cybozu/golang:1.15-focal as builder
 
 WORKDIR /workspace
 

--- a/initialize/Dockerfile
+++ b/initialize/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/cybozu/moco-mysql:8.0.20.4
 ENV GOPATH=/go
 ENV PATH=/go/bin:/usr/local/go/bin:"$PATH"
 
-ARG GO_VERSION=1.13.15
+ARG GO_VERSION=1.15.7
 USER root
 WORKDIR /work
 RUN curl -s -f -O https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \

--- a/operators/set_labels_test.go
+++ b/operators/set_labels_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Set labels", func() {
 			pod0.Spec.Containers = []corev1.Container{
 				{
 					Name:  "ubuntu",
-					Image: "ubuntu:18.04",
+					Image: "ubuntu:20.04",
 				},
 			}
 			return nil
@@ -50,7 +50,7 @@ var _ = Describe("Set labels", func() {
 			pod1.Spec.Containers = []corev1.Container{
 				{
 					Name:  "ubuntu",
-					Image: "ubuntu:18.04",
+					Image: "ubuntu:20.04",
 				},
 			}
 			return nil


### PR DESCRIPTION
- Update Go to 1.15
- Update Ubuntu to 20.04

`go install` outside `GOPATH` will fail with go 1.15 as follows. So I fixed the relevant part to use `go get`.
```
$ make custom-checker
if ! which custom-checker >/dev/null; then \
        cd /tmp; env GOFLAGS= GO111MODULE=on go install github.com/cybozu/neco-containers/golang/analyzer/cmd/custom-checker; \
fi
cannot find module providing package github.com/cybozu/neco-containers/golang/analyzer/cmd/custom-checker: working directory is not part of a module
Makefile:141: recipe for target 'custom-checker' failed
make: *** [custom-checker] Error 1
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>