### PR TITLE
Ready to use upstream MySQL image

### DIFF
--- a/controllers/mysql_conf.go
+++ b/controllers/mysql_conf.go
@@ -78,7 +78,7 @@ var (
 		"innodb_print_all_deadlocks":          "1",
 		"innodb_online_alter_log_max_size":    "1073741824",
 		"innodb_adaptive_hash_index":          "ON",
-		"innodb_numa_interleave":              "ON",
+		"loose_innodb_numa_interleave":        "ON",
 		"innodb_buffer_pool_in_core_file":     "OFF", // It is rarely necessary to include a buffer pool in a core file.
 		"innodb_log_file_size":                "800M",
 		"innodb_log_files_in_group":           "2",

--- a/docs/build-mysql.md
+++ b/docs/build-mysql.md
@@ -48,6 +48,12 @@ FROM mysql:${MYSQL_VERSION}
 COPY --from=download /entrypoint /entrypoint
 COPY --from=download /ping.sh /ping.sh
 
+# The docker official MySQL image doesn't have `/var/lib/mysql-files` which is the default path of the `secure_file_priv` option.
+# Please create the directory as follows or specify the `secure_file_priv` option explicitly.
+# 999 is the user ID of `mysql` user in the docker official MySQL image.
+RUN mkdir -p /var/lib/mysql-files \
+    && chown -R 999:999 /var/lib/mysql-files
+
 ENTRYPOINT ["mysqld"]
 ```
 


### PR DESCRIPTION
I tried to use MOCO with the upstream MySQL Images [`mysql:8.0.20`](https://hub.docker.com/_/mysql) and [`mysql/mysql-server:8.0.20`](https://hub.docker.com/r/mysql/mysql-server/).
Then I faced the following error.

```
2021-01-20T14:40:07.396162Z 0 [ERROR] [MY-000067] [Server] unknown variable 'innodb_numa_interleave=ON'.
```

The mysqld binaries in the upstream images may not be built for a NUMA-enabled Linux.
So they cannot recognize the [`innodb_numa_interleave`](https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_numa_interleave) option.

It's a bother to change the option when using the upstream based image, so I want to add the `loose_` prefix to it.

And add a note for building MySQL image.

Signed-off-by: Masayuki Ishii masa213f@gmail.com