### PR TITLE
Add deletecollection for admin/edit role

### DIFF
--- a/config/rbac/mysqlcluster_editor_role.yaml
+++ b/config/rbac/mysqlcluster_editor_role.yaml
@@ -14,6 +14,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch


### PR DESCRIPTION
In general, the `admin` or `editor` role is also set to `deletecollection`.
Please check the privilege of a namespace admin user by the following command.
```
kubectl -n <namespace> --as=user --as-group=<namespace admin group> --as-group=system:authenticated auth can-i --list
```

Without `deletecollection`, the team-management test in neco-apps will not succeed. :(

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>