### PR TITLE
release build target for kubectl-moco

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,10 +26,7 @@ jobs:
         with:
           go-version: ${{ env.go-version }}
       - run: |
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build/kubectl-moco
-          mv build/kubectl-moco build/kubectl-moco-linux-amd64
-          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 make build/kubectl-moco
-          mv build/kubectl-moco build/kubectl-moco-windows-amd64
+          make release-build
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -57,6 +54,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/kubectl-moco-windows-amd64
-          asset_name: kubectl-moco-windows-amd64
+          asset_path: ./build/kubectl-moco-windows-amd64.exe
+          asset_name: kubectl-moco-windows-amd64.exec
+          asset_content_type: application/octet-stream
+      - name: Upload kubectl-moco for darwin-amd64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build/kubectl-moco-darwin-amd64
+          asset_name: kubectl-moco-darwin-amd64
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build/kubectl-moco-windows-amd64.exe
-          asset_name: kubectl-moco-windows-amd64.exec
+          asset_name: kubectl-moco-windows-amd64.exe
           asset_content_type: application/octet-stream
       - name: Upload kubectl-moco for darwin-amd64
         uses: actions/upload-release-asset@v1

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,24 @@ build/kubectl-moco: $(GO_FILES)
 	mkdir -p build
 	GO111MODULE=on go build -o $@ ./cmd/kubectl-moco
 
+.PHONY: release-build
+release-build: build/kubectl-moco-linux-amd64 build/kubectl-moco-windows-amd64.exe build/kubectl-moco-darwin-amd64
+
+# Build kubectl-moco binary for linux (release build)
+build/kubectl-moco-linux-amd64: $(GO_FILES)
+	mkdir -p build
+	GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $@ ./cmd/kubectl-moco
+
+# Build kubectl-moco binary for Windows (release build)
+build/kubectl-moco-windows-amd64.exe: $(GO_FILES)
+	mkdir -p build
+	GO111MODULE=on CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o $@ ./cmd/kubectl-moco
+
+# Build kubectl-moco binary for Mac OS (release build)
+build/kubectl-moco-darwin-amd64: $(GO_FILES)
+	mkdir -p build
+	GO111MODULE=on CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $@ ./cmd/kubectl-moco
+
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
 manifests: $(CONTROLLER_GEN)


### PR DESCRIPTION
```
$ make release-build
$ file build/*
build/kubectl-moco-darwin-amd64:      Mach-O 64-bit x86_64 executable
build/kubectl-moco-linux-amd64:       ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
build/kubectl-moco-windows-amd64.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>