### PR TITLE
Update controller secret

### DIFF
--- a/cmd/kubectl-moco/cmd/common.go
+++ b/cmd/kubectl-moco/cmd/common.go
@@ -14,7 +14,7 @@ func getPassword(ctx context.Context, clusterName, user string) (string, error) 
 	secret := &corev1.Secret{}
 	err := kubeClient.Get(ctx, types.NamespacedName{
 		Namespace: namespace,
-		Name:      moco.GetRootPasswordSecretName(clusterName),
+		Name:      moco.GetClusterSecretName(clusterName),
 	}, secret)
 	if err != nil {
 		return "", err

--- a/cmd/moco-controller/cmd/run.go
+++ b/cmd/moco-controller/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cybozu-go/moco"
 	"github.com/cybozu-go/moco/accessor"
 	mocov1alpha1 "github.com/cybozu-go/moco/api/v1alpha1"
 	"github.com/cybozu-go/moco/controllers"
@@ -46,7 +47,7 @@ func subMain() error {
 		MetricsBindAddress:      config.metricsAddr,
 		LeaderElection:          true,
 		LeaderElectionID:        config.leaderElectionID,
-		LeaderElectionNamespace: os.Getenv("POD_NAMESPACE"),
+		LeaderElectionNamespace: os.Getenv(moco.PodNamespaceEnvName),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -66,7 +67,8 @@ func subMain() error {
 			ConnectionTimeout: config.connectionTimeout,
 			ReadTimeout:       config.readTimeout,
 		}),
-		WaitTime: config.waitTime,
+		WaitTime:        config.waitTime,
+		SystemNamespace: os.Getenv(moco.PodNamespaceEnvName),
 	}).SetupWithManager(mgr, 30*time.Second); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MySQLCluster")
 		return err

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -128,8 +128,8 @@ var _ = Describe("MySQLCluster controller", func() {
 			Expect(isUpdated).Should(BeTrue())
 
 			ctrlSecretName := moco.GetControllerSecretName(cluster)
-			rootPasswordSecretNS := cluster.Namespace
-			rootPasswordSecretName := moco.GetRootPasswordSecretName(cluster.Name)
+			clusterSecretNS := cluster.Namespace
+			clusterSecretName := moco.GetClusterSecretName(cluster.Name)
 			myCnfSecretName := moco.GetMyCnfSecretName(cluster.Name)
 			myCnfSecretNS := cluster.Namespace
 
@@ -145,17 +145,17 @@ var _ = Describe("MySQLCluster controller", func() {
 			Expect(ctrlSecret.Data).Should(HaveKey(moco.ReadOnlyPasswordKey))
 			Expect(ctrlSecret.Data).Should(HaveKey(moco.WritablePasswordKey))
 
-			rootPasswordSecret := &corev1.Secret{}
-			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: rootPasswordSecretNS, Name: rootPasswordSecretName}, rootPasswordSecret)
+			clusterSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterSecretNS, Name: clusterSecretName}, clusterSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(rootPasswordSecret.Data).Should(HaveKey(moco.RootPasswordKey))
-			Expect(rootPasswordSecret.Data).Should(HaveKey(moco.OperatorPasswordKey))
-			Expect(rootPasswordSecret.Data).Should(HaveKey(moco.ReplicationPasswordKey))
-			Expect(rootPasswordSecret.Data).Should(HaveKey(moco.CloneDonorPasswordKey))
-			Expect(rootPasswordSecret.Data).Should(HaveKey(moco.MiscPasswordKey))
-			Expect(rootPasswordSecret.Data).Should(HaveKey(moco.ReadOnlyPasswordKey))
-			Expect(rootPasswordSecret.Data).Should(HaveKey(moco.WritablePasswordKey))
+			Expect(clusterSecret.Data).Should(HaveKey(moco.RootPasswordKey))
+			Expect(clusterSecret.Data).Should(HaveKey(moco.OperatorPasswordKey))
+			Expect(clusterSecret.Data).Should(HaveKey(moco.ReplicationPasswordKey))
+			Expect(clusterSecret.Data).Should(HaveKey(moco.CloneDonorPasswordKey))
+			Expect(clusterSecret.Data).Should(HaveKey(moco.MiscPasswordKey))
+			Expect(clusterSecret.Data).Should(HaveKey(moco.ReadOnlyPasswordKey))
+			Expect(clusterSecret.Data).Should(HaveKey(moco.WritablePasswordKey))
 
 			myCnfSecret := &corev1.Secret{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: myCnfSecretNS, Name: myCnfSecretName}, myCnfSecret)
@@ -170,19 +170,19 @@ var _ = Describe("MySQLCluster controller", func() {
 			Expect(isUpdated).Should(BeFalse())
 		})
 
-		It("if delete rootPasswordSecret and myConfSecret, they will be regenerated", func() {
+		It("if delete clusterSecret and myConfSecret, they will be regenerated", func() {
 			ctrlSecretName := moco.GetControllerSecretName(cluster)
 			ctrlSecret := &corev1.Secret{}
 			err := k8sClient.Get(ctx, client.ObjectKey{Namespace: systemNamespace, Name: ctrlSecretName}, ctrlSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			rootPasswordSecretNS := cluster.Namespace
-			rootPasswordSecretName := moco.GetRootPasswordSecretName(cluster.Name)
-			rootPasswordSecret := &corev1.Secret{}
-			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: rootPasswordSecretNS, Name: rootPasswordSecretName}, rootPasswordSecret)
+			clusterSecretNS := cluster.Namespace
+			clusterSecretName := moco.GetClusterSecretName(cluster.Name)
+			clusterSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterSecretNS, Name: clusterSecretName}, clusterSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = k8sClient.Delete(ctx, rootPasswordSecret)
+			err = k8sClient.Delete(ctx, clusterSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			myCnfSecretNS := cluster.Namespace
@@ -198,7 +198,7 @@ var _ = Describe("MySQLCluster controller", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(isUpdated).Should(BeTrue())
 
-			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: rootPasswordSecretNS, Name: rootPasswordSecretName}, rootPasswordSecret)
+			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterSecretNS, Name: clusterSecretName}, clusterSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: myCnfSecretNS, Name: myCnfSecretName}, myCnfSecret)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	mathrand "math/rand"
-	"os"
 	"time"
 
 	"github.com/cybozu-go/moco"
@@ -90,9 +89,6 @@ var _ = Describe("MySQLCluster controller", func() {
 			return nil
 		})
 		Expect(err).ShouldNot(HaveOccurred())
-
-		err = os.Setenv("POD_NAMESPACE", systemNamespace)
-		Expect(err).ShouldNot(HaveOccurred())
 	})
 
 	Context("ServerIDBase", func() {
@@ -131,14 +127,14 @@ var _ = Describe("MySQLCluster controller", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(isUpdated).Should(BeTrue())
 
-			ctrlSecretNS, ctrlSecretName := moco.GetSecretNameForController(cluster)
+			ctrlSecretName := moco.GetControllerSecretName(cluster)
 			rootPasswordSecretNS := cluster.Namespace
 			rootPasswordSecretName := moco.GetRootPasswordSecretName(cluster.Name)
 			myCnfSecretName := moco.GetMyCnfSecretName(cluster.Name)
 			myCnfSecretNS := cluster.Namespace
 
 			ctrlSecret := &corev1.Secret{}
-			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: ctrlSecretNS, Name: ctrlSecretName}, ctrlSecret)
+			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: systemNamespace, Name: ctrlSecretName}, ctrlSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(ctrlSecret.Data).Should(HaveKey(moco.RootPasswordKey))
@@ -175,9 +171,9 @@ var _ = Describe("MySQLCluster controller", func() {
 		})
 
 		It("if delete rootPasswordSecret and myConfSecret, they will be regenerated", func() {
-			ctrlSecretNS, ctrlSecretName := moco.GetSecretNameForController(cluster)
+			ctrlSecretName := moco.GetControllerSecretName(cluster)
 			ctrlSecret := &corev1.Secret{}
-			err := k8sClient.Get(ctx, client.ObjectKey{Namespace: ctrlSecretNS, Name: ctrlSecretName}, ctrlSecret)
+			err := k8sClient.Get(ctx, client.ObjectKey{Namespace: systemNamespace, Name: ctrlSecretName}, ctrlSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			rootPasswordSecretNS := cluster.Namespace

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -81,6 +81,7 @@ var _ = BeforeSuite(func(done Done) {
 		CurlContainerImage:     "dummy",
 		MySQLAccessor:          &AccessorMock{},
 		WaitTime:               10 * time.Second,
+		SystemNamespace:        systemNamespace,
 	}
 	Expect(err).ToNot(HaveOccurred())
 

--- a/utils.go
+++ b/utils.go
@@ -20,8 +20,8 @@ func GetPodName(clusterName string, index int) string {
 	return fmt.Sprintf("moco-%s-%d", clusterName, index)
 }
 
-// GetRootPasswordSecretName returns the name of the root password secret.
-func GetRootPasswordSecretName(clusterName string) string {
+// GetClusterSecretName returns the name of the root password secret.
+func GetClusterSecretName(clusterName string) string {
 	return fmt.Sprintf("moco-root-password-%s", clusterName)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -41,18 +41,18 @@ func GetHost(cluster *mocov1alpha1.MySQLCluster, index int) string {
 	return fmt.Sprintf("%s.%s.%s.svc", podName, UniqueName(cluster), cluster.Namespace)
 }
 
-// GetSecretNameForController returns the namespace and Secret name of the cluster
-func GetSecretNameForController(cluster *mocov1alpha1.MySQLCluster) (string, string) {
-	myNS := os.Getenv("POD_NAMESPACE")
+// GetControllerSecretName returns the namespace and Secret name of the cluster
+func GetControllerSecretName(cluster *mocov1alpha1.MySQLCluster) string {
 	mySecretName := cluster.Namespace + "." + cluster.Name // TODO: clarify assumptions for length and charset
-	return myNS, mySecretName
+	return mySecretName
 }
 
 // GetPassword gets a password from secret
 func GetPassword(ctx context.Context, cluster *mocov1alpha1.MySQLCluster, c client.Client, passwordKey string) (string, error) {
+	ctrlNamespace := os.Getenv(PodNamespaceEnvName)
+	ctrlSecretName := GetControllerSecretName(cluster)
 	secret := &corev1.Secret{}
-	myNS, mySecretName := GetSecretNameForController(cluster)
-	err := c.Get(ctx, client.ObjectKey{Namespace: myNS, Name: mySecretName}, secret)
+	err := c.Get(ctx, client.ObjectKey{Namespace: ctrlNamespace, Name: ctrlSecretName}, secret)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Update logic from v0.5.1.

If there is a lack of passwords in a ControllerSecret, fill in missing passwords from a ClusterSecret.
And some refactor.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>