### PR TITLE
Stop using moco-conf-gen

### DIFF
--- a/cmd/moco-controller/cmd/root.go
+++ b/cmd/moco-controller/cmd/root.go
@@ -35,7 +35,7 @@ var rootCmd = &cobra.Command{
 }
 
 const (
-	defaultBinaryCopyContainerImage = "ghcr.io/cybozu-go/moco-agent:0.2.1"
+	defaultBinaryCopyContainerImage = "ghcr.io/cybozu-go/moco-agent:0.3.0"
 	defaultCurlContainerImage       = "quay.io/cybozu/ubuntu:20.04"
 )
 

--- a/cmd/moco-controller/cmd/root.go
+++ b/cmd/moco-controller/cmd/root.go
@@ -36,7 +36,6 @@ var rootCmd = &cobra.Command{
 
 const (
 	defaultBinaryCopyContainerImage = "ghcr.io/cybozu-go/moco-agent:0.2.1"
-	defaultInitContainerImage       = "quay.io/cybozu/moco-conf-gen:0.3.0"
 	defaultCurlContainerImage       = "quay.io/cybozu/ubuntu:20.04"
 )
 

--- a/cmd/moco-controller/cmd/root.go
+++ b/cmd/moco-controller/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -16,7 +15,6 @@ var config struct {
 	metricsAddr              string
 	leaderElectionID         string
 	binaryCopyContainerImage string
-	confInitContainerImage   string
 	curlContainerImage       string
 	connMaxLifeTime          time.Duration
 	connectionTimeout        time.Duration
@@ -30,12 +28,6 @@ var rootCmd = &cobra.Command{
 	Short:   "MOCO controller",
 	Long:    `MOCO controller manages MySQL cluster with binlog-based semi-sync replication.`,
 
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if config.confInitContainerImage == "" {
-			return errors.New("conf-init-container-image is mandatory")
-		}
-		return nil
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		return subMain()
@@ -62,7 +54,6 @@ func init() {
 	fs.StringVar(&config.metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to")
 	fs.StringVar(&config.leaderElectionID, "leader-election-id", "moco", "ID for leader election by controller-runtime")
 	fs.StringVar(&config.binaryCopyContainerImage, "binary-copy-container-image", defaultBinaryCopyContainerImage, "The container image name that includes moco's binaries")
-	fs.StringVar(&config.confInitContainerImage, "conf-init-container-image", defaultInitContainerImage, "The container image name of moco-conf-gen")
 	fs.StringVar(&config.curlContainerImage, "curl-container-image", defaultCurlContainerImage, "The container image name of curl")
 	fs.DurationVar(&config.connMaxLifeTime, connMaxLifetimeFlag, 30*time.Minute, "The maximum amount of time a connection may be reused")
 	fs.DurationVar(&config.connectionTimeout, connectionTimeoutFlag, 3*time.Second, "Dial timeout")

--- a/cmd/moco-controller/cmd/run.go
+++ b/cmd/moco-controller/cmd/run.go
@@ -60,7 +60,6 @@ func subMain() error {
 		Recorder:                 mgr.GetEventRecorderFor("moco-controller"),
 		Scheme:                   mgr.GetScheme(),
 		BinaryCopyContainerImage: config.binaryCopyContainerImage,
-		ConfInitContainerImage:   config.confInitContainerImage,
 		CurlContainerImage:       config.curlContainerImage,
 		MySQLAccessor: accessor.NewMySQLAccessor(&accessor.MySQLAccessorConfig{
 			ConnMaxLifeTime:   config.connMaxLifeTime,

--- a/constants.go
+++ b/constants.go
@@ -127,9 +127,6 @@ const (
 	// PodNameFlag is a name of the flag of a pod IP.
 	PodIPFlag = "pod-ip"
 
-	// NodeNameEnvName is a name of the environment variable of a node name where the pod runs.
-	NodeNameEnvName = "NODE_NAME"
-
 	// NodeNameFlag is a name of the flag of a node name where the pod runs.
 	NodeNameFlag = "node-name"
 

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -1137,8 +1137,6 @@ func (r *MySQLClusterReconciler) makeEntrypointInitContainer(log logr.Logger, cl
 				},
 			},
 		},
-	)
-	c.Env = append(c.Env,
 		corev1.EnvVar{
 			Name: moco.PodNameEnvName,
 			ValueFrom: &corev1.EnvVarSource{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -74,14 +74,13 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(k8sClient).ToNot(BeNil())
 
 	reconciler = &MySQLClusterReconciler{
-		Client:                 k8sClient,
-		Log:                    ctrl.Log.WithName("controllers").WithName("MySQLCluster"),
-		Scheme:                 sch,
-		ConfInitContainerImage: "dummy",
-		CurlContainerImage:     "dummy",
-		MySQLAccessor:          &AccessorMock{},
-		WaitTime:               10 * time.Second,
-		SystemNamespace:        systemNamespace,
+		Client:             k8sClient,
+		Log:                ctrl.Log.WithName("controllers").WithName("MySQLCluster"),
+		Scheme:             sch,
+		CurlContainerImage: "dummy",
+		MySQLAccessor:      &AccessorMock{},
+		WaitTime:           10 * time.Second,
+		SystemNamespace:    systemNamespace,
 	}
 	Expect(err).ToNot(HaveOccurred())
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -119,12 +119,13 @@ and the User configuration for a certain MySQL cluster specified in the cluster'
 The operator then merges these three configurations to create a `my.cnf` template.
 The init container receives the merged `my.cnf` template and fills it with run-time values, e.g. the Pod's IP address.
 
-So, in short we prepare the following two init containers.
-1. A container to initialize the MySQL cluster, for example, creating necessary users.
-  For this purpose, the `moco-agent` binary is provided by [cybozu-go/moco-agent](https://github.com/cybozu-go/moco-agent).
-  If users want to use their custom image, they have to include the binary in the image.
-2. A container to fill the `my.cnf` template received from the operator into a file.
-  This container is injected by the operator.
+So, in short we prepare an init container that does the following two things.
+
+1. Initialize the MySQL cluster, for example, creating necessary users.
+2. Export the `my.cnf` template received from the operator to a file.
+
+For this purpose, the `moco-agent` binary is provided by [cybozu-go/moco-agent](https://github.com/cybozu-go/moco-agent).
+If users want to use their custom image, they have to include the binary in the image.
 
 If users want to change their MySQL cluster configuration, users basically should execute mysql commands like `SET GLOBAL ...`.
 In case that we cannot avoid restarting MySQL cluster to apply changes in the user-defined `ConfigMap`,

--- a/docs/moco-controller.md
+++ b/docs/moco-controller.md
@@ -9,25 +9,29 @@ Usage:
   moco-controller [flags]
 
 Flags:
-      --conf-init-container-image string   The container image name of moco-conf-gen (default " quay.io/cybozu/moco-conf-gen:1.0.0")
-      --constant-conf-configmap string     The ConfigMap name of the constant (== forced) MySQL configration
-      --default-conf-configmap string      The ConfigMap name of the default MySQL configration
-  -h, --help                               help for moco-controller
-      --leader-election-id string          ID for leader election by controller-runtime (default "moco")
-      --metrics-addr string                The address the metric endpoint binds to (default ":8080")
-      --version                            version for moco-controller
-
-klog flags:
-      --add_dir_header                     If true, adds the file directory to the header
-      --alsologtostderr                    log to standard error as well as files
-      --log_backtrace_at traceLocation     when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                     If non-empty, write log files in this directory
-      --log_file string                    If non-empty, use this log file
-      --log_file_max_size uint             Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                        log to standard error instead of files (default true)
-      --skip_headers                       If true, avoid header prefixes in the log messages
-      --skip_log_headers                   If true, avoid headers when opening log files
-      --stderrthreshold severity           logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                            number for the log level verbosity
-      --vmodule moduleSpec                 comma-separated list of pattern=N settings for file-filtered logging
+      --add_dir_header                       If true, adds the file directory to the header
+      --alsologtostderr                      log to standard error as well as files
+      --binary-copy-container-image string   The container image name that includes moco's binaries (default "ghcr.io/cybozu-go/moco-agent:0.2.0")
+      --conn-max-lifetime duration           The maximum amount of time a connection may be reused (default 30m0s)
+      --connection-timeout duration          Dial timeout (default 3s)
+      --curl-container-image string          The container image name of curl (default "quay.io/cybozu/ubuntu:20.04")
+  -h, --help                                 help for moco-controller
+      --leader-election-id string            ID for leader election by controller-runtime (default "moco")
+      --log_backtrace_at traceLocation       when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                       If non-empty, write log files in this directory
+      --log_file string                      If non-empty, use this log file
+      --log_file_max_size uint               Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logfile string                       Log filename
+      --logformat string                     Log format [plain,logfmt,json]
+      --loglevel string                      Log level [critical,error,warning,info,debug]
+      --logtostderr                          log to standard error instead of files (default true)
+      --metrics-addr string                  The address the metric endpoint binds to (default ":8080")
+      --read-timeout duration                I/O read timeout (default 30s)
+      --skip_headers                         If true, avoid header prefixes in the log messages
+      --skip_log_headers                     If true, avoid headers when opening log files
+      --stderrthreshold severity             logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                              number for the log level verbosity
+      --version                              version for moco-controller
+      --vmodule moduleSpec                   comma-separated list of pattern=N settings for file-filtered logging
+      --wait-time duration                   The waiting time which some tasks are under processing (default 10s)
 ```

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -10,8 +10,6 @@ KUSTOMIZE := $(PWD)/bin/kustomize
 KIND_CLUSTER_NAME=moco-e2e
 KUBECTL_MOCO := $(PWD)/bin/kubectl-moco
 
-MOCO_CONF_GEN_VERSION=0.3.0
-
 GO_FILES := $(shell find .. -path ../e2e -prune -o -name '*.go' -print)
 
 .PHONY: default
@@ -40,7 +38,7 @@ test: launch-kind load-image $(KUBECTL_MOCO) setup
 
 .PHONY: telepresence
 telepresence:
-	telepresence --namespace moco-system --swap-deployment moco-controller-manager --run go run ../cmd/moco-controller/main.go --conf-init-container-image=quay.io/cybozu/moco-conf-gen:$(MOCO_CONF_GEN_VERSION)
+	telepresence --namespace moco-system --swap-deployment moco-controller-manager --run go run ../cmd/moco-controller/main.go
 
 .PHONY: load-image
 load-image: load-moco-image load-mysql-image


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/174

## ⚠️ Warning

This pull request depends on the following pull request changes:
https://github.com/cybozu-go/moco-agent/pull/14

Merge the dependent pull requests, release moco-agent, and rerun the E2E tests.
Until then, the test of this pull request will continue to fail.

## Overview

Stop using moco-conf-gen.
moco-conf-gen process is now included in the moco-agent initialization process.

## Tests

E2E tests will not work properly without a Container Image with modified moco-agent code.

This is the result of running it on my local machine:

```console
$ pwd # moco-agent repo
/path/to/dir/github.com/cybozu-go/moco-agent

$ git branch
* d-kuro/move-moco-conf-gen
  main

$ docker build . -t moco-agent:dev # Create a container image with the modified code
$ kind load docker-image moco-agent:dev --name moco-e2e # Load the kind cluster
```

```console
$ pwd # moco repo
/path/to/dir/github.com/cybozu-go/moco

$ git diff # add the binary-copy-container-image options for controller
diff --git a/e2e/manifests/moco_controller.yaml b/e2e/manifests/moco_controller.yaml
index 5ed7b0e..e1a6161 100644
--- a/e2e/manifests/moco_controller.yaml
+++ b/e2e/manifests/moco_controller.yaml
@@ -9,3 +9,6 @@ spec:
       containers:
       - name: manager
         imagePullPolicy: Never
+        args:
+          - "--binary-copy-container-image"
+          - "moco-agent:dev"

$ BOOTSTRAP=1 make test
...
•
Ran 3 of 3 Specs in 37.778 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped

$ kubectl get po -n e2e-test # working fine MySQL cluster
NAME                  READY   STATUS    RESTARTS   AGE
moco-mysqlcluster-0   4/4     Running   0          97s
moco-mysqlcluster-1   4/4     Running   0          97s
moco-mysqlcluster-2   4/4     Running   0          97s
```