### PR TITLE
Migrate from filebeat to fluent-bit

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -271,7 +271,7 @@ The sidecar container rotates and deletes the log files based on the cron spec i
 The operator does not care about gathering the contents of the log files.
 Tenant users can extract the contents by defining sidecar containers for `slow.log` and `error.log`.
 
-You can see an example with FileBeat in [Example Document](example_mysql_cluster.md).
+You can see an example with Fluent Bit in [Example Document](example_mysql_cluster.md).
 
 ### How to delete resources (garbage collection)
 

--- a/docs/example_mysql_cluster.md
+++ b/docs/example_mysql_cluster.md
@@ -58,50 +58,36 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       - name: err-log
-        image: quay.io/cybozu/filebeat:7.9.2.1
-        args: ["-c", "/etc/filebeat.yml"]
+        image: fluent/fluent-bit:1.7.2
         volumeMounts:
-        - name: err-filebeat-config
-          mountPath: /etc/filebeat.yml
+        - name: err-fluent-bit-config
+          mountPath: /fluent-bit/etc/fluent-bit.conf
           readOnly: true
-          subPath: filebeat.yml
-        - name: err-filebeat-data
-          mountPath: /var/lib/filebeat
+          subPath: fluent-bit.conf
         - name: var-log
           mountPath: /var/log/mysql
           readOnly: true
-        - name: tmp
-          mountPath: /tmp
       - name: slow-log
-        image: quay.io/cybozu/filebeat:7.9.2.1
-        args: ["-c", "/etc/filebeat.yml"]
+        image: fluent/fluent-bit:1.7.2
         volumeMounts:
-        - name: slow-filebeat-config
-          mountPath: /etc/filebeat.yml
+        - name: slow-fluent-bit-config
+          mountPath: /fluent-bit/etc/fluent-bit.conf
           readOnly: true
-          subPath: filebeat.yml
-        - name: slow-filebeat-data
-          mountPath: /var/lib/filebeat
+          subPath: fluent-bit.conf
         - name: var-log
           mountPath: /var/log/mysql
           readOnly: true
-        - name: tmp
-          mountPath: /tmp
       securityContext:
         runAsUser: 10000
         runAsGroup: 10000
         fsGroup: 10000
       volumes:
-      - name: err-filebeat-config
+      - name: err-fluent-bit-config
         configMap:
-          name: err-filebeat-config
-      - name: err-filebeat-data
-        emptyDir: {}
-      - name: slow-filebeat-config
+          name: err-fluent-bit-config
+      - name: slow-fluent-bit-config
         configMap:
-          name: slow-filebeat-config
-      - name: slow-filebeat-data
-        emptyDir: {}
+          name: slow-fluent-bit-config
   dataVolumeClaimTemplateSpec:
     storageClassName: topolvm-provisioner
     accessModes: [ "ReadWriteOnce" ]
@@ -124,46 +110,40 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: err-filebeat-config
+  name: err-fluent-bit-config
   namespace: sandbox
 data:
-  filebeat.yml: |-
-    path.data: /var/lib/filebeat
-    filebeat.inputs:
-    - type: log
-      enabled: true
-      paths:
-        - /var/log/mysql/mysql.err*
-    output.console:
-      codec.format:
-        string: '%{[message]}'
-    logging.files:
-      path: /tmp
-      name: filebeat
-      keepfiles: 7
-      permissions: 0644
+  fluent-bit.conf: |-
+    [INPUT]
+      Name           tail
+      Path           /var/log/mysql/mysql.err
+      Read_from_Head true
+    [OUTPUT]
+      Name     file
+      Match    *
+      Path     /dev
+      File     stdout
+      Format   template
+      Template {log}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: slow-filebeat-config
+  name: slow-fluent-bit-config
   namespace: sandbox
 data:
-  filebeat.yml: |-
-    path.data: /var/lib/filebeat
-    filebeat.inputs:
-    - type: log
-      enabled: true
-      paths:
-        - /var/log/mysql/mysql.slow*
-    output.console:
-      codec.format:
-        string: '%{[message]}'
-    logging.files:
-      path: /tmp
-      name: filebeat
-      keepfiles: 7
-      permissions: 0644
+  fluent-bit.conf: |-
+    [INPUT]
+      Name           tail
+      Path           /var/log/mysql/mysql.slow
+      Read_from_Head true
+    [OUTPUT]
+      Name     file
+      Match    *
+      Path     /dev
+      File     stdout
+      Format   template
+      Template {log}
 ```
 
 .metadata.namespace
@@ -212,14 +192,14 @@ They extract logs from MySQL log files into their `stdout` streams.
 The logs are then handled by Kubernetes.
 You can see the logs by `kubectl logs -c err-log <pod_name>` and `kubectl logs -c slow-log <pod_name>`.
 
-The logging containers use [Filebeat](https://www.elastic.co/beats/filebeat) to tail the rotated log files without loss.
+The logging containers use [Fluent Bit](https://fluentbit.io/) to tail the rotated log files without loss.
 This command is not included in the MySQL container image.
 You can use other log-shipping tools for exporting logs to `stdout` and/or the external log database.
 
-The logging containers mount several volumes including `var-log` and `tmp`.
-The two are not listed explicitly in `volumes` because they are managed by MOCO.
+The logging containers mount several volumes including `var-log`.
+`var-log` is not listed explicitly in `volumes` because they are managed by MOCO.
 
-The ConfigMaps used to give the configuration of Filebeat have general names, `err-filebeat-config` and `slow-filebeat-config`, because they can be shared among multiple MySQLClusters.
+The ConfigMaps used to give the configuration of Filebeat have general names, `err-fluent-bit-config` and `slow-fluent-bit-config`, because they can be shared among multiple MySQLClusters.
 
 .spec.podTemplate.spec.volumes
 ------------------------------

--- a/docs/example_mysql_cluster.md
+++ b/docs/example_mysql_cluster.md
@@ -199,7 +199,7 @@ You can use other log-shipping tools for exporting logs to `stdout` and/or the e
 The logging containers mount several volumes including `var-log`.
 `var-log` is not listed explicitly in `volumes` because they are managed by MOCO.
 
-The ConfigMaps used to give the configuration of Filebeat have general names, `err-fluent-bit-config` and `slow-fluent-bit-config`, because they can be shared among multiple MySQLClusters.
+The ConfigMaps used to give the configuration of Fluent Bit have general names, `err-fluent-bit-config` and `slow-fluent-bit-config`, because they can be shared among multiple MySQLClusters.
 
 .spec.podTemplate.spec.volumes
 ------------------------------

--- a/e2e/manifests/mysql_cluster.yaml
+++ b/e2e/manifests/mysql_cluster.yaml
@@ -27,50 +27,36 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       - name: err-log
-        image: quay.io/cybozu/filebeat:7.9.2.1
-        args: ["-c", "/etc/filebeat.yml"]
+        image: fluent/fluent-bit:1.7.2
         volumeMounts:
-        - name: err-filebeat-config
-          mountPath: /etc/filebeat.yml
+        - name: err-fluent-bit-config
+          mountPath: /fluent-bit/etc/fluent-bit.conf
           readOnly: true
-          subPath: filebeat.yml
-        - name: err-filebeat-data
-          mountPath: /var/lib/filebeat
+          subPath: fluent-bit.conf
         - name: var-log
           mountPath: /var/log/mysql
           readOnly: true
-        - name: tmp
-          mountPath: /tmp
       - name: slow-log
-        image: quay.io/cybozu/filebeat:7.9.2.1
-        args: ["-c", "/etc/filebeat.yml"]
+        image: fluent/fluent-bit:1.7.2
         volumeMounts:
-        - name: slow-filebeat-config
-          mountPath: /etc/filebeat.yml
+        - name: slow-fluent-bit-config
+          mountPath: /fluent-bit/etc/fluent-bit.conf
           readOnly: true
-          subPath: filebeat.yml
-        - name: slow-filebeat-data
-          mountPath: /var/lib/filebeat
+          subPath: fluent-bit.conf
         - name: var-log
           mountPath: /var/log/mysql
           readOnly: true
-        - name: tmp
-          mountPath: /tmp
       securityContext:
         runAsUser: 10000
         runAsGroup: 10000
         fsGroup: 10000
       volumes:
-      - name: err-filebeat-config
+      - name: err-fluent-bit-config
         configMap:
-          name: err-filebeat-config
-      - name: err-filebeat-data
-        emptyDir: {}
-      - name: slow-filebeat-config
+          name: err-fluent-bit-config
+      - name: slow-fluent-bit-config
         configMap:
-          name: slow-filebeat-config
-      - name: slow-filebeat-data
-        emptyDir: {}
+          name: slow-fluent-bit-config
   dataVolumeClaimTemplateSpec:
     accessModes: [ "ReadWriteOnce" ]
     resources:
@@ -92,41 +78,35 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: err-filebeat-config
+  name: err-fluent-bit-config
 data:
-  filebeat.yml: |-
-    path.data: /var/lib/filebeat
-    filebeat.inputs:
-    - type: log
-      enabled: true
-      paths:
-        - /var/log/mysql/mysql.err*
-    output.console:
-      codec.format:
-        string: '%{[message]}'
-    logging.files:
-      path: /tmp
-      name: filebeat
-      keepfiles: 7
-      permissions: 0644
+  fluent-bit.conf: |-
+    [INPUT]
+      Name           tail
+      Path           /var/log/mysql/mysql.err
+      Read_from_Head true
+    [OUTPUT]
+      Name     file
+      Match    *
+      Path     /dev
+      File     stdout
+      Format   template
+      Template {log}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: slow-filebeat-config
+  name: slow-fluent-bit-config
 data:
-  filebeat.yml: |-
-    path.data: /var/lib/filebeat
-    filebeat.inputs:
-    - type: log
-      enabled: true
-      paths:
-        - /var/log/mysql/mysql.slow*
-    output.console:
-      codec.format:
-        string: '%{[message]}'
-    logging.files:
-      path: /tmp
-      name: filebeat
-      keepfiles: 7
-      permissions: 0644
+  fluent-bit.conf: |-
+    [INPUT]
+      Name           tail
+      Path           /var/log/mysql/mysql.slow
+      Read_from_Head true
+    [OUTPUT]
+      Name     file
+      Match    *
+      Path     /dev
+      File     stdout
+      Format   template
+      Template {log}

--- a/e2e/manifests/mysql_cluster_external.yaml
+++ b/e2e/manifests/mysql_cluster_external.yaml
@@ -28,50 +28,36 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       - name: err-log
-        image: quay.io/cybozu/filebeat:7.9.2.1
-        args: ["-c", "/etc/filebeat.yml"]
+        image: fluent/fluent-bit:1.7.2
         volumeMounts:
-        - name: err-filebeat-config
-          mountPath: /etc/filebeat.yml
+        - name: err-fluent-bit-config
+          mountPath: /fluent-bit/etc/fluent-bit.conf
           readOnly: true
-          subPath: filebeat.yml
-        - name: err-filebeat-data
-          mountPath: /var/lib/filebeat
+          subPath: fluent-bit.conf
         - name: var-log
           mountPath: /var/log/mysql
           readOnly: true
-        - name: tmp
-          mountPath: /tmp
       - name: slow-log
-        image: quay.io/cybozu/filebeat:7.9.2.1
-        args: ["-c", "/etc/filebeat.yml"]
+        image: fluent/fluent-bit:1.7.2
         volumeMounts:
-        - name: slow-filebeat-config
-          mountPath: /etc/filebeat.yml
+        - name: slow-fluent-bit-config
+          mountPath: /fluent-bit/etc/fluent-bit.conf
           readOnly: true
-          subPath: filebeat.yml
-        - name: slow-filebeat-data
-          mountPath: /var/lib/filebeat
+          subPath: fluent-bit.conf
         - name: var-log
           mountPath: /var/log/mysql
           readOnly: true
-        - name: tmp
-          mountPath: /tmp
       securityContext:
         runAsUser: 10000
         runAsGroup: 10000
         fsGroup: 10000
       volumes:
-      - name: err-filebeat-config
-        configMap:
-          name: err-filebeat-config
-      - name: err-filebeat-data
-        emptyDir: {}
-      - name: slow-filebeat-config
-        configMap:
-          name: slow-filebeat-config
-      - name: slow-filebeat-data
-        emptyDir: {}
+        - name: err-fluent-bit-config
+          configMap:
+            name: err-fluent-bit-config
+        - name: slow-fluent-bit-config
+          configMap:
+            name: slow-fluent-bit-config
   dataVolumeClaimTemplateSpec:
     accessModes: [ "ReadWriteOnce" ]
     resources:
@@ -93,41 +79,35 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: err-filebeat-config
+  name: err-fluent-bit-config
 data:
-  filebeat.yml: |-
-    path.data: /var/lib/filebeat
-    filebeat.inputs:
-    - type: log
-      enabled: true
-      paths:
-        - /var/log/mysql/mysql.err*
-    output.console:
-      codec.format:
-        string: '%{[message]}'
-    logging.files:
-      path: /tmp
-      name: filebeat
-      keepfiles: 7
-      permissions: 0644
+  fluent-bit.conf: |-
+    [INPUT]
+      Name           tail
+      Path           /var/log/mysql/mysql.err
+      Read_from_Head true
+    [OUTPUT]
+      Name     file
+      Match    *
+      Path     /dev
+      File     stdout
+      Format   template
+      Template {log}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: slow-filebeat-config
+  name: slow-fluent-bit-config
 data:
-  filebeat.yml: |-
-    path.data: /var/lib/filebeat
-    filebeat.inputs:
-    - type: log
-      enabled: true
-      paths:
-        - /var/log/mysql/mysql.slow*
-    output.console:
-      codec.format:
-        string: '%{[message]}'
-    logging.files:
-      path: /tmp
-      name: filebeat
-      keepfiles: 7
-      permissions: 0644
+  fluent-bit.conf: |-
+    [INPUT]
+      Name           tail
+      Path           /var/log/mysql/mysql.slow
+      Read_from_Head true
+    [OUTPUT]
+      Name     file
+      Match    *
+      Path     /dev
+      File     stdout
+      Format   template
+      Template {log}


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/171

This is one of the pull requests that will be split.
This pull request replaces the existing filebeat container with a fluent-bit container.
After this pull request, I will submit a change to define the default fluent-bit container and allow end users to customize the fluent-bit container.