### PR TITLE
metrics: simplify status metrics into whether status is true or not.

### DIFF
--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -334,7 +334,7 @@ func selectInitializedCluster(obj client.Object) []string {
 			return []string{string(cond.Status)}
 		}
 	}
-	return []string{string(corev1.ConditionUnknown)}
+	return nil
 }
 
 func (r *MySQLClusterReconciler) setServerIDBaseIfNotAssigned(ctx context.Context, log logr.Logger, cluster *mocov1alpha1.MySQLCluster) (bool, error) {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -5,15 +5,15 @@ Metrics
 
 MOCO controller exposes the following metrics with the Prometheus format.  All these metrics are prefixed with `moco_controller_`
 
-| Name                     | Description                                        | Type    | Labels               |
-| ------------------------ | -------------------------------------------------- | ------- | -------------------- |
-| operation_phase          | The operation is in the labeled phase or not       | Gauge   | cluster_name, phase  |
-| failover_count_total     | The failover count                                 | Counter | cluster_name         |
-| total_replicas           | The number of replicas                             | Gauge   | cluster_name         |
-| synced_replicas          | The number of replicas which are in "synced" state | Gauge   | cluster_name         |
-| cluster_violation_status | The cluster status about violation condition       | Gauge   | cluster_name, status |
-| cluster_failure_status   | The cluster status about failure condition         | Gauge   | cluster_name, status |
-| cluster_healthy_status   | The cluster status about healthy condition         | Gauge   | cluster_name, status |
-| cluster_available_status | The cluster status about available condition       | Gauge   | cluster_name, status |
+| Name                     | Description                                        | Type    | Labels              |
+| ------------------------ | -------------------------------------------------- | ------- | ------------------- |
+| operation_phase          | The operation is in the labeled phase or not       | Gauge   | cluster_name, phase |
+| failover_count_total     | The failover count                                 | Counter | cluster_name        |
+| total_replicas           | The number of replicas                             | Gauge   | cluster_name        |
+| synced_replicas          | The number of replicas which are in "synced" state | Gauge   | cluster_name        |
+| cluster_violation_status | The cluster status about violation condition       | Gauge   | cluster_name        |
+| cluster_failure_status   | The cluster status about failure condition         | Gauge   | cluster_name        |
+| cluster_healthy_status   | The cluster status about healthy condition         | Gauge   | cluster_name        |
+| cluster_available_status | The cluster status about available condition       | Gauge   | cluster_name        |
 
 Note that MOCO controller also exposes the metrics provided by the Prometheus client library which located under `go` and `process` namespaces. [The metrics](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/internal/controller/metrics) exposed by `controller-runtime` is also available.

--- a/metrics/deleter.go
+++ b/metrics/deleter.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"github.com/cybozu-go/moco"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func DeleteAllControllerMetrics(clusterName string) {
@@ -35,25 +34,17 @@ func deleteSyncedReplicasMetrics(clusterName string) {
 }
 
 func deleteClusterStatusViolationMetrics(clusterName string) {
-	for _, c := range []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionUnknown} {
-		clusterViolationStatusMetrics.DeleteLabelValues(clusterName, string(c))
-	}
+	clusterViolationStatusMetrics.DeleteLabelValues(clusterName)
 }
 
 func deleteClusterStatusFailureMetrics(clusterName string) {
-	for _, c := range []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionUnknown} {
-		clusterFailureStatusMetrics.DeleteLabelValues(clusterName, string(c))
-	}
+	clusterFailureStatusMetrics.DeleteLabelValues(clusterName)
 }
 
 func deleteClusterStatusHealthyMetrics(clusterName string) {
-	for _, c := range []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionUnknown} {
-		clusterHealthyStatusMetrics.DeleteLabelValues(clusterName, string(c))
-	}
+	clusterHealthyStatusMetrics.DeleteLabelValues(clusterName)
 }
 
 func deleteClusterStatusAvailableMetrics(clusterName string) {
-	for _, c := range []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionUnknown} {
-		clusterAvailableStatusMetrics.DeleteLabelValues(clusterName, string(c))
-	}
+	clusterAvailableStatusMetrics.DeleteLabelValues(clusterName)
 }

--- a/metrics/deleter_test.go
+++ b/metrics/deleter_test.go
@@ -24,14 +24,10 @@ func TestDeleteAllMetrics(t *testing.T) {
 		UpdateTotalReplicasMetrics(c, 3)
 		UpdateSyncedReplicasMetrics(c, intPointer(2))
 		IncrementFailoverCountTotalMetrics(c)
-		for _, f := range []func(c string, status corev1.ConditionStatus){
-			UpdateClusterStatusViolationMetrics,
-			UpdateClusterStatusFailureMetrics,
-			UpdateClusterStatusHealthyMetrics,
-			UpdateClusterStatusAvailableMetrics,
-		} {
-			f(c, corev1.ConditionTrue)
-		}
+		UpdateClusterStatusViolationMetrics(c, corev1.ConditionTrue)
+		UpdateClusterStatusFailureMetrics(c, corev1.ConditionTrue)
+		UpdateClusterStatusHealthyMetrics(c, corev1.ConditionTrue)
+		UpdateClusterStatusAvailableMetrics(c, corev1.ConditionTrue)
 	}
 
 	beforeDelete, err := registry.Gather()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -26,7 +26,7 @@ func RegisterMetrics(registry *prometheus.Registry) {
 		Subsystem: metricsSubsystem,
 		Name:      "cluster_violation_status",
 		Help:      "The cluster status about violation condition",
-	}, []string{"cluster_name", "status"})
+	}, []string{"cluster_name"})
 	registry.MustRegister(clusterViolationStatusMetrics)
 
 	clusterFailureStatusMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -34,7 +34,7 @@ func RegisterMetrics(registry *prometheus.Registry) {
 		Subsystem: metricsSubsystem,
 		Name:      "cluster_failure_status",
 		Help:      "The cluster status about failure condition",
-	}, []string{"cluster_name", "status"})
+	}, []string{"cluster_name"})
 	registry.MustRegister(clusterFailureStatusMetrics)
 
 	clusterAvailableStatusMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -42,7 +42,7 @@ func RegisterMetrics(registry *prometheus.Registry) {
 		Subsystem: metricsSubsystem,
 		Name:      "cluster_available_status",
 		Help:      "The cluster status about available condition",
-	}, []string{"cluster_name", "status"})
+	}, []string{"cluster_name"})
 	registry.MustRegister(clusterAvailableStatusMetrics)
 
 	clusterHealthyStatusMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -50,7 +50,7 @@ func RegisterMetrics(registry *prometheus.Registry) {
 		Subsystem: metricsSubsystem,
 		Name:      "cluster_healthy_status",
 		Help:      "The cluster status about healthy condition",
-	}, []string{"cluster_name", "status"})
+	}, []string{"cluster_name"})
 	registry.MustRegister(clusterHealthyStatusMetrics)
 
 	operationPhaseMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/metrics/updater.go
+++ b/metrics/updater.go
@@ -49,11 +49,9 @@ func UpdateClusterStatusAvailableMetrics(clusterName string, status corev1.Condi
 }
 
 func updateClusterStatusMetrics(target *prometheus.GaugeVec, clusterName string, status corev1.ConditionStatus) {
-	for _, c := range []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionUnknown} {
-		if status == c {
-			target.WithLabelValues(clusterName, string(c)).Set(1)
-			continue
-		}
-		target.WithLabelValues(clusterName, string(c)).Set(0)
+	if status == corev1.ConditionTrue {
+		target.WithLabelValues(clusterName).Set(1)
+	} else {
+		target.WithLabelValues(clusterName).Set(0)
 	}
 }

--- a/runners/suite_test.go
+++ b/runners/suite_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/cybozu-go/moco"
 
 	. "github.com/onsi/ginkgo"
@@ -92,5 +90,5 @@ func selectInitializedCluster(obj client.Object) []string {
 			return []string{string(cond.Status)}
 		}
 	}
-	return []string{string(corev1.ConditionUnknown)}
+	return nil
 }


### PR DESCRIPTION
This PR simplifies cluster status metrics.
This also removes the use of `ConditionUnknown` in indexer functions.

Original:
```
moco_controller_cluster_healthy_status{cluster_name="foo", status="true"} 1.0
moco_controller_cluster_healthy_status{cluster_name="foo", status="false"} 0.0
moco_controller_cluster_healthy_status{cluster_name="foo", status="unknown"} 0.0
```

Simplified:
```
moco_controller_cluster_healthy_status{cluster_name="foo"} 1.0
```

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>