### PR TITLE
Fix image tag

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,6 +60,7 @@ Bump version
     $ git tag v$VERSION
     $ git push origin v$VERSION
     ```
+10. Update the image tag of `ghcr.io/cybozu-go/moco` in `config/manager/manager.yaml`
 
 ## (Option) Edit GitHub release page
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
       - name: manager
         command:
         - /moco-controller
-        image: ghcr.io/cybozu-go/moco:latest
+        image: ghcr.io/cybozu-go/moco:0.7.0
         resources:
           requests:
             memory: 256Mi


### PR DESCRIPTION
I could not setup this operator with the given configs and I found out that the controller image tag is incorrect.

```
inductor@vm:~$ docker pull ghcr.io/cybozu-go/moco:latest
Error response from daemon: name unknown
inductor@vm:~$ docker pull ghcr.io/cybozu-go/moco:0.7.0
0.7.0: Pulling from cybozu-go/moco
83ee3a23efb7: Pull complete
db98fc6f11f0: Pull complete
f611acd52c6c: Pull complete
686294eef510: Pull complete
e6006b494f03: Pull complete
e7a099f8a1b9: Pull complete
2cc57e483531: Pull complete
Digest: sha256:acacfd013f75a2211506ef805c489d9137518c5e493c3cbcb406847ddfd86026
Status: Downloaded newer image for ghcr.io/cybozu-go/moco:0.7.0
ghcr.io/cybozu-go/moco:0.7.0
```