### PR TITLE
Kill connections in the old primary upon a switchover

### DIFF
--- a/clustering/agent.go
+++ b/clustering/agent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cybozu-go/moco/pkg/constants"
 	"github.com/cybozu-go/moco/pkg/dbop"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 // AgentConn represents a gRPC connection to a moco-agent
@@ -52,7 +53,10 @@ func (f defaultAgentFactory) New(ctx context.Context, cluster *mocov1beta1.MySQL
 		return nil, err
 	}
 	addr := net.JoinHostPort(ip, strconv.Itoa(constants.AgentPort))
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithBlock(), grpc.WithInsecure())
+	kp := keepalive.ClientParameters{
+		Time: 1 * time.Minute,
+	}
+	conn, err := grpc.DialContext(ctx, addr, grpc.WithBlock(), grpc.WithInsecure(), grpc.WithKeepaliveParams(kp))
 	if err != nil {
 		return agentConn{}, err
 	}

--- a/clustering/mock_test.go
+++ b/clustering/mock_test.go
@@ -437,6 +437,10 @@ func (o *mockOperator) SetReadOnly(ctx context.Context, readonly bool) error {
 	return setPodReadiness(ctx, o.cluster.PodName(o.index), true)
 }
 
+func (o *mockOperator) KillConnections(ctx context.Context) error {
+	return nil
+}
+
 type mockMySQL struct {
 	mu     sync.Mutex
 	status dbop.MySQLInstanceStatus

--- a/clustering/operations.go
+++ b/clustering/operations.go
@@ -128,6 +128,9 @@ func (p *managerProcess) switchover(ctx context.Context, ss *StatusSet) error {
 		return fmt.Errorf("failed to make instance %d read-only: %w", ss.Primary, err)
 	}
 	time.Sleep(100 * time.Millisecond)
+	if err := pdb.KillConnections(ctx); err != nil {
+		return fmt.Errorf("failed to kill connections in instance %d: %w", ss.Primary, err)
+	}
 	pst, err := pdb.GetStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get the primary status: %w", err)

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -194,9 +194,10 @@ The switchover is done as follows.
 It takes at least several seconds for a new primary to become writable.
 
 1. Make the primary instance `super_read_only=1`.
-2. Wait for a replica to catch up the executed GTID set of the primary instance.
-3. Set `status.currentPrimaryIndex` to the replica's index.
-4. If the old primary is Demoting, remove `moco.cybozu.com/demote` annotation from the Pod.
+2. Kill all existing connections except ones from `localhost` and ones for MOCO.
+3. Wait for a replica to catch up the executed GTID set of the primary instance.
+4. Set `status.currentPrimaryIndex` to the replica's index.
+5. If the old primary is Demoting, remove `moco.cybozu.com/demote` annotation from the Pod.
 
 #### Cloning
 

--- a/pkg/constants/users.go
+++ b/pkg/constants/users.go
@@ -12,6 +12,16 @@ const (
 	WritableUser    = "moco-writable"
 )
 
+// MocoSystemUsers is a map to hold system users.
+var MocoSystemUsers = map[string]bool{
+	AdminUser:       true,
+	AgentUser:       true,
+	ReplicationUser: true,
+	CloneDonorUser:  true,
+	ExporterUser:    true,
+	BackupUser:      true,
+}
+
 // my.cnf filenames for different kind of users.
 const (
 	AdminMyCnf    = AdminUser + "-my.cnf"

--- a/pkg/dbop/kill.go
+++ b/pkg/dbop/kill.go
@@ -1,0 +1,30 @@
+package dbop
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cybozu-go/moco/pkg/constants"
+)
+
+func (o *operator) KillConnections(ctx context.Context) error {
+	var procs []Process
+
+	if err := o.db.SelectContext(ctx, &procs, `SELECT ID, USER, HOST FROM information_schema.PROCESSLIST`); err != nil {
+		return fmt.Errorf("failed to get process list: %w", err)
+	}
+
+	for _, p := range procs {
+		if constants.MocoSystemUsers[p.User] {
+			continue
+		}
+		if p.Host == "localhost" {
+			continue
+		}
+
+		if _, err := o.db.ExecContext(ctx, `KILL CONNECTION ?`, p.ID); err != nil {
+			return fmt.Errorf("failed to kill connection %d for %s from %s: %w", p.ID, p.User, p.Host, err)
+		}
+	}
+	return nil
+}

--- a/pkg/dbop/kill_test.go
+++ b/pkg/dbop/kill_test.go
@@ -1,0 +1,68 @@
+package dbop
+
+import (
+	"context"
+	"fmt"
+
+	mocov1beta1 "github.com/cybozu-go/moco/api/v1beta1"
+	"github.com/cybozu-go/moco/pkg/password"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("kill", func() {
+	It("should kill non-system processes only", func() {
+		By("preparing a single node cluster")
+		cluster := &mocov1beta1.MySQLCluster{}
+		cluster.Namespace = "test"
+		cluster.Name = "kill"
+		cluster.Spec.Replicas = 1
+
+		passwd, err := password.NewMySQLPassword()
+		Expect(err).NotTo(HaveOccurred())
+
+		op, err := factory.New(context.Background(), cluster, passwd, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a user and making a connection with the user")
+		_, err = op.(*operator).db.Exec("SET GLOBAL read_only=0")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = op.(*operator).db.Exec("CREATE USER 'foo'@'%' IDENTIFIED BY 'bar'")
+		Expect(err).NotTo(HaveOccurred())
+		db, err := factory.(*testFactory).newConn(context.Background(), cluster, "foo", "bar", 0)
+		Expect(err).NotTo(HaveOccurred())
+		defer db.Close()
+
+		By("getting process list")
+		var procs []Process
+		err = op.(*operator).db.Select(&procs, `SELECT ID, USER, HOST FROM information_schema.PROCESSLIST`)
+		Expect(err).NotTo(HaveOccurred())
+
+		fooFound := false
+		for _, p := range procs {
+			fmt.Printf("process %d for %s from %s\n", p.ID, p.User, p.Host)
+			if p.User == "foo" {
+				fooFound = true
+			}
+		}
+		Expect(fooFound).To(BeTrue())
+
+		By("killing user process")
+		err = op.KillConnections(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+
+		var procs2 []Process
+		err = op.(*operator).db.Select(&procs2, `SELECT ID, USER, HOST FROM information_schema.PROCESSLIST`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(procs) - len(procs2)).To(Equal(1))
+
+		fooFound = false
+		for _, p := range procs2 {
+			fmt.Printf("process %d for %s from %s\n", p.ID, p.User, p.Host)
+			if p.User == "foo" {
+				fooFound = true
+			}
+		}
+		Expect(fooFound).To(BeFalse())
+	})
+})

--- a/pkg/dbop/operator.go
+++ b/pkg/dbop/operator.go
@@ -58,6 +58,10 @@ type Operator interface {
 	// SetReadOnly makes the instance super_read_only if `true` is passed.
 	// Otherwise, this stops the replication and makes the instance writable.
 	SetReadOnly(context.Context, bool) error
+
+	// KillConnections kills all connections except for ones from `localhost`
+	// and ones for MOCO.
+	KillConnections(context.Context) error
 }
 
 // OperatorFactory represents the factory for Operators.

--- a/pkg/dbop/types.go
+++ b/pkg/dbop/types.go
@@ -129,3 +129,10 @@ func (rs *ReplicaStatus) IsRunning() bool {
 type CloneStatus struct {
 	State sql.NullString `db:"state"`
 }
+
+// Process represents a process in `information_schema.PROCESSLIST` table.
+type Process struct {
+	ID   uint64 `db:"ID"`
+	User string `db:"USER"`
+	Host string `db:"HOST"`
+}


### PR DESCRIPTION
After a switchover, connections in the old primary will probably
not be usable.  To notify clients of the event earlier, MOCO should
kill the existing connections in the old primary.

The implementation does not kill connections from `localhost`
because some system processes such as `event_scheduler` have
such connections.  Also, it does not kill MOCO system users'
connections.