### PR TITLE
controllers: set UID/GID of containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.3] - 2021-05-12
+
+### Changed
+- Set UID/GID of containers to 10000:10000 (#243)
+
 ## [0.8.2] - 2021-05-10
 
 ### Changed
@@ -150,7 +155,8 @@ The `MySQLCluster` created by MOCO `< v0.5.0` has no compatibility with `>= v0.5
 
 - Bootstrap a vanilla MySQL cluster with no replicas (#2).
 
-[Unreleased]: https://github.com/cybozu-go/moco/compare/v0.8.2...HEAD
+[Unreleased]: https://github.com/cybozu-go/moco/compare/v0.8.3...HEAD
+[0.8.3]: https://github.com/cybozu-go/moco/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/cybozu-go/moco/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/cybozu-go/moco/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/cybozu-go/moco/compare/v0.7.0...v0.8.0

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 )
 
 func (r *MySQLClusterReconciler) makeV1MySQLDContainer(cluster *mocov1beta1.MySQLCluster, desired, current []corev1.Container) (corev1.Container, error) {
@@ -291,6 +292,12 @@ func (r *MySQLClusterReconciler) makeV1InitContainer(cluster *mocov1beta1.MySQLC
 }
 
 func updateContainerWithSupplements(container *corev1.Container, currentContainers []corev1.Container) {
+	if container.SecurityContext == nil {
+		container.SecurityContext = &corev1.SecurityContext{}
+	}
+	container.SecurityContext.RunAsUser = pointer.Int64(constants.ContainerUID)
+	container.SecurityContext.RunAsGroup = pointer.Int64(constants.ContainerGID)
+
 	var current *corev1.Container
 	for i, c := range currentContainers {
 		if c.Name == container.Name {

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -607,6 +607,11 @@ var _ = Describe("MySQLCluster reconciler", func() {
 		foundSlowLogAgent := false
 		foundExporter := false
 		for _, c := range sts.Spec.Template.Spec.Containers {
+			Expect(c.SecurityContext).NotTo(BeNil())
+			Expect(c.SecurityContext.RunAsUser).NotTo(BeNil())
+			Expect(*c.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
+			Expect(c.SecurityContext.RunAsGroup).NotTo(BeNil())
+			Expect(*c.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerGID)))
 			switch c.Name {
 			case constants.MysqldContainerName:
 				foundMysqld = true
@@ -633,6 +638,11 @@ var _ = Describe("MySQLCluster reconciler", func() {
 		Expect(initContainer.Name).To(Equal(constants.InitContainerName))
 		Expect(initContainer.Image).To(Equal("moco-mysql:latest"))
 		Expect(initContainer.Command).To(ContainElement(fmt.Sprintf("%d", cluster.Spec.ServerIDBase)))
+		Expect(initContainer.SecurityContext).NotTo(BeNil())
+		Expect(initContainer.SecurityContext.RunAsUser).NotTo(BeNil())
+		Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
+		Expect(initContainer.SecurityContext.RunAsGroup).NotTo(BeNil())
+		Expect(*initContainer.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerGID)))
 
 		Expect(sts.Spec.VolumeClaimTemplates).To(HaveLen(1))
 		Expect(sts.Spec.VolumeClaimTemplates[0].Name).To(Equal(constants.MySQLDataVolumeName))

--- a/pkg/constants/container.go
+++ b/pkg/constants/container.go
@@ -23,6 +23,12 @@ const (
 	MOCOBinVolumeName                 = "moco-bin"
 )
 
+// UID/GID
+const (
+	ContainerUID = 10000
+	ContainerGID = 10000
+)
+
 // command names
 const (
 	InitCommand = "moco-init"


### PR DESCRIPTION
to avoid mismatched UID/GID and root execution.