### PR TITLE
Do not apply Service template to the headless Service

### DIFF
--- a/e2e/manager_patch.yaml
+++ b/e2e/manager_patch.yaml
@@ -14,5 +14,7 @@ spec:
         - --check-interval=5s
         - --backup-image=moco-backup:dev
         env:
+        - name: DEBUG_CONTROLLER
+          value: "1"
         - name: TEST_NO_JOB_RESOURCE
           value: "1"


### PR DESCRIPTION
The headless Service should not be configurable.
Fixes #249

Also, the Service reconciler is improved not to overwrite dual-stack related fields.