### PR TITLE
controllers: fix a bug in ServiceTemplate reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.3] - 2021-06-02
+
+### Fixed
+- Failed to update Service if `spec.externalTrafficPolicy` was set to `Local` (#259)
+
 ## [0.9.2] - 2021-06-01
 
 ### Changed
@@ -180,7 +185,8 @@ The `MySQLCluster` created by MOCO `< v0.5.0` has no compatibility with `>= v0.5
 
 - Bootstrap a vanilla MySQL cluster with no replicas (#2).
 
-[Unreleased]: https://github.com/cybozu-go/moco/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/cybozu-go/moco/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/cybozu-go/moco/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/cybozu-go/moco/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/cybozu-go/moco/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/cybozu-go/moco/compare/v0.8.3...v0.9.0

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -539,6 +539,9 @@ func (r *MySQLClusterReconciler) reconcileV1Service1(ctx context.Context, cluste
 		if len(saSpec.ExternalTrafficPolicy) == 0 {
 			saSpec.ExternalTrafficPolicy = svc.Spec.ExternalTrafficPolicy
 		}
+		if saSpec.HealthCheckNodePort == 0 {
+			saSpec.HealthCheckNodePort = svc.Spec.HealthCheckNodePort
+		}
 		if saSpec.IPFamilies == nil {
 			saSpec.IPFamilies = svc.Spec.IPFamilies
 		}

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 
 images:
 - name: ghcr.io/cybozu-go/moco
-  newTag: 0.9.2
+  newTag: 0.9.3

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package moco
 
 const (
 	// Version is the MOCO version
-	Version = "0.9.2"
+	Version = "0.9.3"
 
 	// FluentBitImage is the image for slow-log sidecar container.
 	FluentBitImage = "quay.io/cybozu/fluent-bit:1.7.5.1"


### PR DESCRIPTION
It failed to update Services when `spec.externalTrafficPolicy` was set to `Local`.