### PR TITLE
Fix cloning bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.5] - 2021-06-04
+
+### Fixed
+- Timeout while cloning large data (#261)
+- Better handling of Cloning state (#261)
+- Manual switch over did not take place immediately (#261)
+
+### Changed
+- Update `moco-agent` to 0.6.6 (#261)
+
 ## [0.9.4] - 2021-06-03
 
 ### Fixed
@@ -190,7 +200,8 @@ The `MySQLCluster` created by MOCO `< v0.5.0` has no compatibility with `>= v0.5
 
 - Bootstrap a vanilla MySQL cluster with no replicas (#2).
 
-[Unreleased]: https://github.com/cybozu-go/moco/compare/v0.9.4...HEAD
+[Unreleased]: https://github.com/cybozu-go/moco/compare/v0.9.5...HEAD
+[0.9.5]: https://github.com/cybozu-go/moco/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/cybozu-go/moco/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/cybozu-go/moco/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/cybozu-go/moco/compare/v0.9.1...v0.9.2

--- a/api/v1beta1/mysqlcluster_types.go
+++ b/api/v1beta1/mysqlcluster_types.go
@@ -337,6 +337,10 @@ type MySQLClusterStatus struct {
 	// +optional
 	RestoredTime *metav1.Time `json:"restoredTime,omitempty"`
 
+	// Cloned indicates if the initial cloning from an external source has been completed.
+	// +optional
+	Cloned bool `json:"cloned,omitempty"`
+
 	// ReconcileInfo represents version information for reconciler.
 	// +optional
 	ReconcileInfo ReconcileInfo `json:"reconcileInfo"`

--- a/clustering/manager_test.go
+++ b/clustering/manager_test.go
@@ -324,6 +324,10 @@ var _ = Describe("manager", func() {
 				return err
 			}
 
+			if cluster.Status.Cloned {
+				return errors.New("status.cloned is set to true")
+			}
+
 			for _, cond := range cluster.Status.Conditions {
 				if cond.Type != mocov1beta1.ConditionInitialized {
 					continue
@@ -388,6 +392,8 @@ var _ = Describe("manager", func() {
 			}
 			return fmt.Errorf("no health condition")
 		}).Should(Succeed())
+
+		Expect(cluster.Status.Cloned).To(BeTrue())
 
 		events := &corev1.EventList{}
 		err = k8sClient.List(ctx, events, client.InNamespace("test"))

--- a/clustering/status.go
+++ b/clustering/status.go
@@ -349,9 +349,13 @@ func isCloning(ss *StatusSet) bool {
 		return false
 	}
 
+	if ss.Cluster.Status.Cloned {
+		return false
+	}
+
 	pst := ss.MySQLStatus[ss.Primary]
 	if pst == nil {
-		return false
+		return true
 	}
 
 	if pst.CloneStatus != nil && pst.CloneStatus.State.String != "Completed" {

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -5248,6 +5248,9 @@ spec:
                 - warnings
                 - workDirUsage
                 type: object
+              cloned:
+                description: Cloned indicates if the initial cloning from an external source has been completed.
+                type: boolean
               conditions:
                 description: Conditions is an array of conditions.
                 items:

--- a/controllers/pod_watcher.go
+++ b/controllers/pod_watcher.go
@@ -5,6 +5,7 @@ import (
 
 	mocov1beta1 "github.com/cybozu-go/moco/api/v1beta1"
 	"github.com/cybozu-go/moco/clustering"
+	"github.com/cybozu-go/moco/pkg/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ func (r *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if pod.DeletionTimestamp == nil {
+	if pod.DeletionTimestamp == nil && pod.Annotations[constants.AnnDemote] != "true" {
 		return ctrl.Result{}, nil
 	}
 

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -80,6 +80,7 @@ Likewise, if a replica Pod is ready, the `mysqld` is assured read-only and runni
     - For intermediate primary instance, the primary works as a replica for an external `mysqld` and is read-only.
 2. Cloning
     - `spec.replicationSourceSecretName` is set.
+    - `status.cloned` is false.
     - The cloning result exists and is not "Completed" _or_ there is no cloning result and the instance has no data.
     - (note: if the primary has some data and has no cloning result, the instance was used to be a replica and then promoted to the primary.)
 3. Restoring
@@ -179,6 +180,7 @@ In this phase, MOCO updates `status` field of MySQLCluster as follows:
 5. Add newly found errant replicas to `status.errantReplicaList`.
 6. Remove re-initialized and/or no-longer errant replicas from `status.errantReplicaList`
 7. Set `status.errantReplicas` to the length of `status.errantReplicaList`.
+8. Set `status.cloned` to true if `spec.replicationSourceSecret` is not nil and the state is not Cloning.
 
 ### Determine what MOCO should do for the cluster
 

--- a/docs/crd_mysqlcluster.md
+++ b/docs/crd_mysqlcluster.md
@@ -111,6 +111,7 @@ MySQLClusterStatus defines the observed state of MySQLCluster
 | errantReplicaList | ErrantReplicaList is the list of indices of errant replicas. | []int | false |
 | backup | Backup is the status of the last successful backup. | [BackupStatus](#backupstatus) | true |
 | restoredTime | RestoredTime is the time when the cluster data is restored. | *[metav1.Time](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Time) | false |
+| cloned | Cloned indicates if the initial cloning from an external source has been completed. | bool | false |
 | reconcileInfo | ReconcileInfo represents version information for reconciler. | [ReconcileInfo](#reconcileinfo) | true |
 
 [Back to Custom Resources](#custom-resources)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.2.1
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.2.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.9.0
-	github.com/cybozu-go/moco-agent v0.6.5
+	github.com/cybozu-go/moco-agent v0.6.6
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/stdr v0.4.0
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cybozu-go/log v1.5.0/go.mod h1:zpfovuCgUx+a/ErvQrThoT+/z1RVQoLDOf95wkBeRiw=
 github.com/cybozu-go/log v1.6.0/go.mod h1:2iAEvn2cL5dy/1uP5Jfb0Ao9+DUnDr//V0Bk3WDJX1U=
-github.com/cybozu-go/moco-agent v0.6.5 h1:h1uhAJ43JuuvtcFTd8bgXpFghbt40dBWD3lJQhVc5Zw=
-github.com/cybozu-go/moco-agent v0.6.5/go.mod h1:emhcINL6P81LZ4o355DETRXs8S63HUAXJN7SK01e7MY=
+github.com/cybozu-go/moco-agent v0.6.6 h1:fzRXL2h3KChp7dSdXtHQ9Sn2CzX6IodRfjrp7fFpAZA=
+github.com/cybozu-go/moco-agent v0.6.6/go.mod h1:emhcINL6P81LZ4o355DETRXs8S63HUAXJN7SK01e7MY=
 github.com/cybozu-go/netutil v1.2.0/go.mod h1:Wx92iF1dPrtuSzLUMEidtrKTFiDWpLcsYvbQ1lHSmxY=
 github.com/cybozu-go/well v1.10.0/go.mod h1:OQdjEXQpbG+kSgEF3t3IYUx5y1R4qeBGvzL4gmi61qE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 
 images:
 - name: ghcr.io/cybozu-go/moco
-  newTag: 0.9.4
+  newTag: 0.9.5

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package moco
 
 const (
 	// Version is the MOCO version
-	Version = "0.9.4"
+	Version = "0.9.5"
 
 	// FluentBitImage is the image for slow-log sidecar container.
 	FluentBitImage = "quay.io/cybozu/fluent-bit:1.7.5.1"


### PR DESCRIPTION
This PR includes multiple bug fixes.

- Failed to clone large data due to a timeout.
- Failed to determine Cloning state correctly.
- Manual switchover might not have taken place immediately.

To fix the first clone bug, `moco-agent` is updated to 0.6.6.