### PR TITLE
Watch ConfigMap for customizing my.cnf

### DIFF
--- a/controllers/pod_watcher.go
+++ b/controllers/pod_watcher.go
@@ -17,7 +17,7 @@ import (
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// PodWatcher Watched MySQL pods and informs the cluster manager of the event.
+// PodWatcher watches MySQL pods and informs the cluster manager of the event.
 type PodWatcher struct {
 	client.Client
 	ClusterManager clustering.ClusterManager


### PR DESCRIPTION
In order to run reconciliation quickly, the controller needs to watch ConfigMap
referenced by `spec.mysqlConfigMapName` field of MySQLCluster.