### PR TITLE
Fix not to be affected by the system time zone

### DIFF
--- a/backup/key.go
+++ b/backup/key.go
@@ -10,7 +10,7 @@ import (
 const prefix = "moco"
 
 func calcKey(clusterNS, clusterName, filename string, dt time.Time) string {
-	return path.Join(prefix, clusterNS, clusterName, dt.Format(constants.BackupTimeFormat), filename)
+	return path.Join(prefix, clusterNS, clusterName, dt.UTC().Format(constants.BackupTimeFormat), filename)
 }
 
 func calcPrefix(clusterNS, clusterName string) string {


### PR DESCRIPTION
MySQLCluster.Status.Backup.Time is affected by the system time zone when it's retrieved.
CalcKey calculates a key for a storing backup file using the time which is affected by the system time zone, and it leads to the problem that RestoreManager can't find target backup files as expected.

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>