### PR TITLE
docs: fix a dead link in GitHub pages

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -21,7 +21,7 @@ That's all!
 
 ## Customize manifests
 
-If you want to edit the manifest, [`config/`](../config/) directory contains the source YAML for [kustomize](https://kustomize.io/).
+If you want to edit the manifest, [`config/`](https://github.com/cybozu-go/moco/tree/main/config) directory contains the source YAML for [kustomize](https://kustomize.io/).
 
 ## Next step
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,7 +113,7 @@ spec:
           storage: 1Gi
 ```
 
-There are other example manifests in [`examples`](../examples/) directory.
+There are other example manifests in [`examples`](https://github.com/cybozu-go/moco/tree/main/examples) directory.
 
 The complete reference of MySQLCluster is [`crd_mysqlcluster.md`](crd_mysqlcluster.md).
 


### PR DESCRIPTION
The link that using relative-path is "404 not found" on GitHub pages.

This PR change URL to the repository from relative-path.
Visitors will is able to found some files.