### PR TITLE
Use workVolume/tmp as TMPDIR for mysqlbinlog

### DIFF
--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -50,7 +50,7 @@ func (o *choosePodMockOp) LoadDump(ctx context.Context, dir string) error {
 	panic("not implemented")
 }
 
-func (o *choosePodMockOp) LoadBinlog(ctx context.Context, dir string, restorePoint time.Time) error {
+func (o *choosePodMockOp) LoadBinlog(ctx context.Context, binlogDir, tmpDir string, restorePoint time.Time) error {
 	panic("not implemented")
 }
 

--- a/backup/mock_test.go
+++ b/backup/mock_test.go
@@ -105,11 +105,11 @@ func (o *mockOperator) LoadDump(ctx context.Context, dir string) error {
 	return err
 }
 
-func (o *mockOperator) LoadBinlog(ctx context.Context, dir string, restorePoint time.Time) error {
+func (o *mockOperator) LoadBinlog(ctx context.Context, binlogDir, tmpDir string, restorePoint time.Time) error {
 	if !o.prepared {
 		return errors.New("not prepared")
 	}
-	entries, err := os.ReadDir(dir)
+	entries, err := os.ReadDir(binlogDir)
 	if err != nil {
 		return err
 	}

--- a/backup/restore.go
+++ b/backup/restore.go
@@ -301,5 +301,13 @@ func (rm *RestoreManager) applyBinlog(ctx context.Context, op bkop.Operator, key
 		return fmt.Errorf("zstd exited abnormally: %w", err)
 	}
 
-	return op.LoadBinlog(ctx, binlogDir, rm.restorePoint)
+	mysqlBinlogTmpdir := filepath.Join(rm.workDir, "tmp")
+	if err := os.MkdirAll(mysqlBinlogTmpdir, 0755); err != nil {
+		return fmt.Errorf("failed to create %s: %w", mysqlBinlogTmpdir, err)
+	}
+	defer func() {
+		os.RemoveAll(mysqlBinlogTmpdir)
+	}()
+
+	return op.LoadBinlog(ctx, binlogDir, mysqlBinlogTmpdir, rm.restorePoint)
 }

--- a/backup/restore.go
+++ b/backup/restore.go
@@ -301,13 +301,14 @@ func (rm *RestoreManager) applyBinlog(ctx context.Context, op bkop.Operator, key
 		return fmt.Errorf("zstd exited abnormally: %w", err)
 	}
 
-	mysqlBinlogTmpdir := filepath.Join(rm.workDir, "tmp")
-	if err := os.MkdirAll(mysqlBinlogTmpdir, 0755); err != nil {
-		return fmt.Errorf("failed to create %s: %w", mysqlBinlogTmpdir, err)
+	// for mysqlbinlog
+	tmpDir := filepath.Join(rm.workDir, "tmp")
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		return fmt.Errorf("failed to create %s: %w", tmpDir, err)
 	}
 	defer func() {
-		os.RemoveAll(mysqlBinlogTmpdir)
+		os.RemoveAll(tmpDir)
 	}()
 
-	return op.LoadBinlog(ctx, binlogDir, mysqlBinlogTmpdir, rm.restorePoint)
+	return op.LoadBinlog(ctx, binlogDir, tmpDir, rm.restorePoint)
 }

--- a/pkg/bkop/operator.go
+++ b/pkg/bkop/operator.go
@@ -39,7 +39,7 @@ type Operator interface {
 	LoadDump(ctx context.Context, dir string) error
 
 	// LoadBinLog applies binary logs up to `restorePoint`.
-	LoadBinlog(ctx context.Context, dir string, restorePoint time.Time) error
+	LoadBinlog(ctx context.Context, binlogDir, tmpDir string, restorePoint time.Time) error
 
 	// FinishRestore sets global variables of the database instance after restoration.
 	FinishRestore(context.Context) error

--- a/pkg/bkop/operator_test.go
+++ b/pkg/bkop/operator_test.go
@@ -169,7 +169,11 @@ var _ = Describe("Operator", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(restoredGTID).To(Equal(dumpGTID))
 
-		err = opRe.LoadBinlog(ctx, binlogDir, restorePoint)
+		tmpDir := filepath.Join(baseDir, "tmp")
+		err = os.MkdirAll(tmpDir, 0755)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = opRe.LoadBinlog(ctx, binlogDir, tmpDir, restorePoint)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(restoredGTID).To(Equal(dumpGTID))
 		var maxID int

--- a/pkg/bkop/restore.go
+++ b/pkg/bkop/restore.go
@@ -94,7 +94,7 @@ func (o operator) LoadBinlog(ctx context.Context, binlogDir, tmpDir string, rest
 	env := os.Environ()
 	env = append(env, "TZ=Etc/UTC")
 	// mysqlbinlog requires enough space to be specified as TMPDIR.
-	env = append(env, fmt.Sprintf("TMPDIR=%s", tmpDir))
+	env = append(env, "TMPDIR="+tmpDir)
 	binlogCmd.Env = env
 
 	mysqlArgs := []string{


### PR DESCRIPTION
When restoring from a backup, we encountered the following error.

```text
mysqlbinlog: Can't create/write to file '/tmp/tmp.HEJ6ct' (OS errno 30 - Read-only file system)
mysqlbinlog: Can't create/write to file '/tmp/tmp.fFkaQp' (OS errno 30 - Read-only file system)
mysqlbinlog: Can't create/write to file '/tmp/tmp.B2u7Xp' (OS errno 30 - Read-only file system)
mysqlbinlog: Can't create/write to file '/tmp/tmp.L82Cpt' (OS errno 30 - Read-only file system)
mysqlbinlog: Can't create/write to file '/tmp/tmp.dFxxlu' (OS errno 30 - Read-only file system)
```

mysqlbinlog requires enough space to be specified as TMPDIR. See the following.
https://dev.mysql.com/doc/refman/8.0/en/mysqlbinlog.html