### PR TITLE
Support krew release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,5 @@
 /docs
 /e2e
 /hack
+/dist
 /.git

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,4 +42,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Update new version in krew-index
-      uses: rajatjindal/krew-release-bot@v0.0.40
+      # v0.0.40 https://github.com/rajatjindal/krew-release-bot/releases/tag/v0.0.40
+      uses: rajatjindal/krew-release-bot@56925b62bacc2c652114d66a8256faaf0bf89fa9

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,13 +33,13 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.go-version }}
-    - run: make release-build
-    - name: Create Release
+    - name: GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        distribution: goreleaser
+        version: v0.180.3
+        args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        tagname="${GITHUB_REF#refs/tags/}"
-        if echo ${{ github.ref }} | grep -q -e '-'; then prerelease=-p; fi
-        gh release create -t "Release $tagname" $prerelease \
-          -n "See [CHANGELOG.md](./CHANGELOG.md) for details." \
-          "$tagname" build/*
+    - name: Update new version in krew-index
+      uses: rajatjindal/krew-release-bot@v0.0.40

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /bin
 /build
 /testbin
+/dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,45 @@
+before:
+  hooks:
+    - make release-manifests-build
+
+builds:
+  - id: kubectl-moco
+    main: ./cmd/kubectl-moco
+    binary: kubectl-moco
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ignore: # ref: https://goreleaser.com/deprecations/#builds-for-windowsarm64
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - builds:
+      - kubectl-moco
+    name_template: "kubectl-{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    wrap_in_directory: false
+    format: tar.gz
+    files:
+      - LICENSE
+      - build/moco.yaml
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  skip: true
+
+release:
+  github:
+    owner: cybozu-go
+    name: moco
+  prerelease: auto
+  name_template: "Release {{ .Tag }}"
+  footer: |
+    See [CHANGELOG.md](./CHANGELOG.md) for details.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,6 @@ archives:
     format: tar.gz
     files:
       - LICENSE
-      - build/moco.yaml
 
 checksum:
   name_template: checksums.txt
@@ -43,3 +42,5 @@ release:
   name_template: "Release {{ .Tag }}"
   footer: |
     See [CHANGELOG.md](./CHANGELOG.md) for details.
+  extra_files:
+    - glob: build/moco.yaml

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,67 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: moco
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/cybozu-go/moco
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      {{addURIAndSha "https://github.com/cybozu-go/moco/releases/download/{{ .TagName }}/kubectl-moco_{{ .TagName }}_darwin_amd64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-moco
+      files:
+        - from: kubectl-moco
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      {{addURIAndSha "https://github.com/cybozu-go/moco/releases/download/{{ .TagName }}/kubectl-moco_{{ .TagName }}_darwin_arm64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-moco
+      files:
+        - from: kubectl-moco
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/cybozu-go/moco/releases/download/{{ .TagName }}/kubectl-moco_{{ .TagName }}_linux_amd64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-moco
+      files:
+        - from: kubectl-moco
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      {{addURIAndSha "https://github.com/cybozu-go/moco/releases/download/{{ .TagName }}/kubectl-moco_{{ .TagName }}_linux_arm64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-moco
+      files:
+        - from: kubectl-moco
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      {{addURIAndSha "https://github.com/cybozu-go/moco/releases/download/{{ .TagName }}/kubectl-moco_{{ .TagName }}_windows_amd64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-moco.exe
+      files:
+        - from: kubectl-moco.exe
+          to: .
+        - from: LICENSE
+          to: .
+  shortDescription: kubectl-moco is a plugin for kubectl to control MySQL clusters of MOCO.
+  description: |
+    kubectl-moco is a plugin for kubectl to control MySQL clusters of MOCO.
+    Read more documentation at: https://cybozu-go.github.io/moco/kubectl-moco.html

--- a/docs/install-plugin.md
+++ b/docs/install-plugin.md
@@ -27,7 +27,7 @@ $ kubectl krew install moco
     $ OS=$(go env GOOS)
     ```
 
-2. Set `ARCH` to the operating system name
+2. Set `ARCH` to the architecture name
 
    ARCH is one of `amd64` or `arm64`.
 

--- a/docs/install-plugin.md
+++ b/docs/install-plugin.md
@@ -4,27 +4,70 @@
 
 Pre-built binaries are available on [GitHub releases](https://github.com/cybozu-go/moco/releases) for Windows, Linux, and MacOS.
 
-Download one of the binaries for your OS and place it in a directory of `PATH`.
+## Installing using Krew
+
+[Krew](https://krew.sigs.k8s.io/) is the plugin manager for kubectl command-line tool.
+
+See the [documentation](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) for how to install Krew.
 
 ```console
-$ curl -fsL -o /path/to/bin/kubectl-moco https://github.com/cybozu-go/moco/releases/latest/download/kubectl-moco-linux-amd64
-$ chmod a+x /path/to/bin/kubectl-moco
+$ kubectl krew update
+$ kubectl krew install moco
 ```
 
-Check the installation by running `kubectl moco -h`.
+## Installing manually
 
-```console
-$ kubectl moco -h
-the utility command for MOCO.
+1. Set `OS` to the operating system name
 
-Usage:
-  kubectl-moco [command]
+   OS is one of `linux`, `windows`, or `darwin` (MacOS).
 
-Available Commands:
-  credential  Fetch the credential of a specified user
-  help        Help about any command
-  mysql       Run mysql command in a specified MySQL instance
-  switchover  Switch the primary instance
+   If Go is available, `OS` can be set automatically as follows:
 
-...
-```
+    ```console
+    $ OS=$(go env GOOS)
+    ```
+
+2. Set `ARCH` to the operating system name
+
+   ARCH is one of `amd64` or `arm64`.
+
+   If Go is available, `ARCH` can be set automatically as follows:
+
+    ```console
+    $ ARCH=$(go env GOARCH)
+    ```
+
+3. Set `VERSION` to the MOCO version
+
+   See the MOCO release page: https://github.com/cybozu-go/moco/releases
+
+   ```console
+   $ VERSION=< The version you want to install >
+   ```
+
+4. Download the binary and put it in a directory of your `PATH`.
+
+   The following is an example to install the plugin in `/usr/local/bin`.
+
+    ```console
+    $ curl -L -sS https://github.com/cybozu-go/moco/releases/download/$(VERSION)/kubectl-moco_$(VERSION)_$(OS)_$(ARCH).tar.gz \
+      | tar xz -C /usr/local/bin kubectl-moco
+    ```
+
+5. Check the installation by running `kubectl moco -h`.
+
+   ```console
+   $ kubectl moco -h
+   the utility command for MOCO.
+   
+   Usage:
+     kubectl-moco [command]
+   
+   Available Commands:
+     credential  Fetch the credential of a specified user
+     help        Help about any command
+     mysql       Run mysql command in a specified MySQL instance
+     switchover  Switch the primary instance
+   
+   ...
+   ```

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -42,7 +42,7 @@ endif
 	$(KUSTOMIZE) build . | $(KUBECTL) apply -f -
 	$(KUBECTL) -n moco-system wait --for=condition=available --timeout=180s --all deployments
 	$(KUBECTL) apply -f minio.yaml
-	$(KUBECTL) wait --for=condition=Ready --all pods
+	$(KUBECTL) wait --timeout=60s --for=condition=Ready --all pods
 
 .PHONY: test
 test:


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/313

Release kubectl-moco plugin to krew-index.

## Review Points

* Build the binary to be released using [goreleaser](https://github.com/goreleaser/goreleaser) and archive it as `.tar.gz`
  * krew plugins must be packaged as .zip or .tar.gz archives
  * https://krew.sigs.k8s.io/docs/developer-guide/plugin-manifest/#specifying-plugin-download-options
* Use krew-release-bot to update krew-index
  * https://krew.sigs.k8s.io/docs/developer-guide/release/automating-updates/

## Work to be done after merging

* Add tar.gz archive to v0.9.5 release
  * This will be done manually
  * `GORELEASER_CURRENT_TAG=v0.9.5 goreleaser release --skip-publish --skip-announce --skip-validate --rm-dist`
* Send a Pull Request to https://github.com/kubernetes-sigs/krew-index

## Testing

I've tested it in my own repository that I forked.

Release:
https://github.com/d-kuro/moco/releases/tag/v0.9.6
https://github.com/d-kuro/moco/actions/runs/1310314467

Generate Krew manifests:

```console
$ docker run -v (pwd):/tmp/ rajatjindal/krew-release-bot:v0.0.40 krew-release-bot template --tag v0.9.6 --template-file /tmp/.krew.yaml
time="2021-10-06T03:57:19Z" level=info msg="getting sha256 for https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_darwin_amd64.tar.gz"
time="2021-10-06T03:57:19Z" level=info msg="downloaded file /tmp/039617384/1633492639"
time="2021-10-06T03:57:19Z" level=info msg="getting sha256 for https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_darwin_arm64.tar.gz"
time="2021-10-06T03:57:20Z" level=info msg="downloaded file /tmp/881145255/1633492639"
time="2021-10-06T03:57:20Z" level=info msg="getting sha256 for https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_linux_amd64.tar.gz"
time="2021-10-06T03:57:21Z" level=info msg="downloaded file /tmp/146106586/1633492640"
time="2021-10-06T03:57:21Z" level=info msg="getting sha256 for https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_linux_arm64.tar.gz"
time="2021-10-06T03:57:22Z" level=info msg="downloaded file /tmp/224831089/1633492641"
time="2021-10-06T03:57:22Z" level=info msg="getting sha256 for https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_windows_amd64.tar.gz"
time="2021-10-06T03:57:23Z" level=info msg="downloaded file /tmp/301952284/1633492642"
apiVersion: krew.googlecontainertools.github.com/v1alpha2
kind: Plugin
metadata:
  name: moco
spec:
  version: v0.9.6
  homepage: https://github.com/cybozu-go/moco
  platforms:
    - selector:
        matchLabels:
          os: darwin
          arch: amd64
      uri: https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_darwin_amd64.tar.gz
      sha256: 3f22b2531c9083290473278a250b258553dcf5155b3c1405953d4faf178ab212
      bin: kubectl-moco
      files:
        - from: kubectl-moco
          to: .
        - from: LICENSE
          to: .
    - selector:
        matchLabels:
          os: darwin
          arch: arm64
      uri: https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_darwin_arm64.tar.gz
      sha256: db0860a23b4691fae9c0bfb367aaed899109da11275002280aff2cadb4a6a295
      bin: kubectl-moco
      files:
        - from: kubectl-moco
          to: .
        - from: LICENSE
          to: .
    - selector:
        matchLabels:
          os: linux
          arch: amd64
apiVersion: krew.googlecontainertools.github.com/v1alpha2
        matchLabels:
        matchLabels:
          to: .
    - selector:
      uri: https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_linux_amd64.tar.gz
      sha256: d1140d1c87565919360a5fbfab4a695d7f6638d207f721c80b814fe5820cdbac
      bin: kubectl-moco
      files:
        - from: kubectl-moco
          to: .
        - from: LICENSE
          to: .
    - selector:
        matchLabels:
          os: linux
          arch: arm64
      uri: https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_linux_arm64.tar.gz
      sha256: be34dd8514fda1233d5629403c3c1cd69516984825a4c8699ddbbf67206afb9f
      bin: kubectl-moco
      files:
        - from: kubectl-moco
          to: .
        - from: LICENSE
          to: .
    - selector:
        matchLabels:
          os: windows
          arch: amd64
      uri: https://github.com/d-kuro/moco/releases/download/v0.9.6/kubectl-moco_v0.9.6_windows_amd64.tar.gz
      sha256: 06faffdd372a06a00ef453a50124785d8c2ae1296fef6dee1995e65dd1dbd81e
      bin: kubectl-moco.exe
      files:
        - from: kubectl-moco.exe
          to: .
        - from: LICENSE
          to: .
  shortDescription: kubectl-moco is a plugin for kubectl to control MySQL clusters of MOCO.
  description: |
    kubectl-moco is a plugin for kubectl to control MySQL clusters of MOCO.
    Read more documentation at: https://cybozu-go.github.io/moco/kubectl-moco.html
```

Install krew manifests:

```console
$ kubectl krew install --manifest=plugin.yaml
Installing plugin: moco
Installed plugin: moco
\
 | Use this plugin:
 | 	kubectl moco
 | Documentation:
 | 	https://github.com/cybozu-go/moco
/
```