### PR TITLE
Add PrimaryServiceTemplate and ReplicaServiceTemplate

### DIFF
--- a/api/v1beta1/mysqlcluster_types.go
+++ b/api/v1beta1/mysqlcluster_types.go
@@ -36,6 +36,12 @@ type MySQLClusterSpec struct {
 	// +optional
 	ServiceTemplate *ServiceTemplate `json:"serviceTemplate,omitempty"`
 
+	// PrimaryServiceTemplate is a `Service` template only for primary mysqld instance.
+	PrimaryServiceTemplate *ServiceTemplate `json:"primaryServiceTemplate,omitempty"`
+
+	// ReplicaServiceTemplate is a `Service` template only for replica mysqld instances.
+	ReplicaServiceTemplate *ServiceTemplate `json:"replicaServiceTemplate,omitempty"`
+
 	// MySQLConfigMapName is a `ConfigMap` name of MySQL config.
 	// +nullable
 	// +optional
@@ -288,7 +294,7 @@ type ServiceTemplate struct {
 	// +optional
 	ObjectMeta `json:"metadata,omitempty"`
 
-	// Spec is the ServiceSpec
+	// Spec is the ServiceSpec.
 	// +optional
 	Spec *corev1.ServiceSpec `json:"spec,omitempty"`
 }

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -277,6 +277,16 @@ func (in *MySQLClusterSpec) DeepCopyInto(out *MySQLClusterSpec) {
 		*out = new(ServiceTemplate)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PrimaryServiceTemplate != nil {
+		in, out := &in.PrimaryServiceTemplate, &out.PrimaryServiceTemplate
+		*out = new(ServiceTemplate)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ReplicaServiceTemplate != nil {
+		in, out := &in.ReplicaServiceTemplate, &out.ReplicaServiceTemplate
+		*out = new(ServiceTemplate)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MySQLConfigMapName != nil {
 		in, out := &in.MySQLConfigMapName, &out.MySQLConfigMapName
 		*out = new(string)

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -5812,6 +5812,416 @@ spec:
                 required:
                 - spec
                 type: object
+              primaryServiceTemplate:
+                description: PrimaryServiceTemplate is a `Service` template only for
+                  primary mysqld instance.
+                properties:
+                  metadata:
+                    description: Standard object's metadata.  Only `annotations` and
+                      `labels` are valid.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values.
+                        type: object
+                      name:
+                        description: Name is the name of the object.
+                        type: string
+                    type: object
+                  spec:
+                    description: Spec is the ServiceSpec.
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: allocateLoadBalancerNodePorts defines if NodePorts
+                          will be automatically allocated for services with type LoadBalancer.  Default
+                          is "true".
+                        type: boolean
+                      clusterIP:
+                        description: clusterIP is the IP address of the service and
+                          is usually assigned randomly.
+                        type: string
+                      clusterIPs:
+                        description: ClusterIPs is a list of IP addresses assigned
+                          to this service, and are usually assigned randomly.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that discovery
+                          mechanisms will return as an alias for this service (e.g.
+                          a DNS CNAME record). No proxying will be involved.  Must
+                          be a lowercase RFC-1123 hostname (https://tools.
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. This only applies when type is
+                          set to LoadBalancer and externalTrafficPolicy is set to
+                          Local.
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: InternalTrafficPolicy specifies if the cluster
+                          internal traffic should be routed to all endpoints or node-local
+                          endpoints only. "Cluster" routes internal traffic to a Service
+                          to all endpoints.
+                        type: string
+                      ipFamilies:
+                        description: IPFamilies is a list of IP families (e.g. IPv4,
+                          IPv6) assigned to this service, and is gated by the "IPv6DualStack"
+                          feature gate.
+                        items:
+                          description: IPFamily represents the IP Family (IPv4 or
+                            IPv6). This type is used to express the family of an IP
+                            expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service, and is gated by the
+                          "IPv6DualStack" feature gate.  If there is no value provided,
+                          then this field will be set to SingleStack.
+                        type: string
+                      loadBalancerClass:
+                        description: loadBalancerClass is the class of the load balancer
+                          implementation this Service belongs to. If specified, the
+                          value of this field must be a label-style identifier, with
+                          an optional prefix, e.g.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: If specified and supported by the platform, this
+                          will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs.
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names.
+                              type: string
+                            nodePort:
+                              description: The port on each node on which this service
+                                is exposed when type is NodePort or LoadBalancer.  Usually
+                                assigned by the system.
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses indicates that any agent
+                          which deals with endpoints for this Service should disregard
+                          any indications of ready/not-ready.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify.
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      topologyKeys:
+                        description: topologyKeys is a preference-order list of topology
+                          keys which implementations of services should use to preferentially
+                          sort endpoints when accessing this Service, it can not be
+                          used at the same time as externalTrafficPo
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: type determines how the Service is exposed. Defaults
+                          to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer.
+                        type: string
+                    type: object
+                type: object
+              replicaServiceTemplate:
+                description: ReplicaServiceTemplate is a `Service` template only for
+                  replica mysqld instances.
+                properties:
+                  metadata:
+                    description: Standard object's metadata.  Only `annotations` and
+                      `labels` are valid.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of string keys and values.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values.
+                        type: object
+                      name:
+                        description: Name is the name of the object.
+                        type: string
+                    type: object
+                  spec:
+                    description: Spec is the ServiceSpec.
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: allocateLoadBalancerNodePorts defines if NodePorts
+                          will be automatically allocated for services with type LoadBalancer.  Default
+                          is "true".
+                        type: boolean
+                      clusterIP:
+                        description: clusterIP is the IP address of the service and
+                          is usually assigned randomly.
+                        type: string
+                      clusterIPs:
+                        description: ClusterIPs is a list of IP addresses assigned
+                          to this service, and are usually assigned randomly.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that discovery
+                          mechanisms will return as an alias for this service (e.g.
+                          a DNS CNAME record). No proxying will be involved.  Must
+                          be a lowercase RFC-1123 hostname (https://tools.
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. This only applies when type is
+                          set to LoadBalancer and externalTrafficPolicy is set to
+                          Local.
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: InternalTrafficPolicy specifies if the cluster
+                          internal traffic should be routed to all endpoints or node-local
+                          endpoints only. "Cluster" routes internal traffic to a Service
+                          to all endpoints.
+                        type: string
+                      ipFamilies:
+                        description: IPFamilies is a list of IP families (e.g. IPv4,
+                          IPv6) assigned to this service, and is gated by the "IPv6DualStack"
+                          feature gate.
+                        items:
+                          description: IPFamily represents the IP Family (IPv4 or
+                            IPv6). This type is used to express the family of an IP
+                            expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service, and is gated by the
+                          "IPv6DualStack" feature gate.  If there is no value provided,
+                          then this field will be set to SingleStack.
+                        type: string
+                      loadBalancerClass:
+                        description: loadBalancerClass is the class of the load balancer
+                          implementation this Service belongs to. If specified, the
+                          value of this field must be a label-style identifier, with
+                          an optional prefix, e.g.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: If specified and supported by the platform, this
+                          will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs.
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names.
+                              type: string
+                            nodePort:
+                              description: The port on each node on which this service
+                                is exposed when type is NodePort or LoadBalancer.  Usually
+                                assigned by the system.
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses indicates that any agent
+                          which deals with endpoints for this Service should disregard
+                          any indications of ready/not-ready.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify.
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      topologyKeys:
+                        description: topologyKeys is a preference-order list of topology
+                          keys which implementations of services should use to preferentially
+                          sort endpoints when accessing this Service, it can not be
+                          used at the same time as externalTrafficPo
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: type determines how the Service is exposed. Defaults
+                          to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer.
+                        type: string
+                    type: object
+                type: object
               replicas:
                 default: 1
                 description: Replicas is the number of instances. Available values
@@ -7414,7 +7824,7 @@ spec:
                         type: string
                     type: object
                   spec:
-                    description: Spec is the ServiceSpec
+                    description: Spec is the ServiceSpec.
                     properties:
                       allocateLoadBalancerNodePorts:
                         description: allocateLoadBalancerNodePorts defines if NodePorts

--- a/docs/crd_mysqlcluster.md
+++ b/docs/crd_mysqlcluster.md
@@ -85,6 +85,8 @@ MySQLClusterSpec defines the desired state of MySQLCluster
 | podTemplate | PodTemplate is a `Pod` template for MySQL server container. | [PodTemplateSpec](#podtemplatespec) | true |
 | volumeClaimTemplates | VolumeClaimTemplates is a list of `PersistentVolumeClaim` templates for MySQL server container. A claim named \"mysql-data\" must be included in the list. | [][PersistentVolumeClaim](#persistentvolumeclaim) | true |
 | serviceTemplate | ServiceTemplate is a `Service` template for both primary and replicas. | *[ServiceTemplate](#servicetemplate) | false |
+| primaryServiceTemplate | PrimaryServiceTemplate is a `Service` template only for primary mysqld instance. | *[ServiceTemplate](#servicetemplate) | false |
+| replicaServiceTemplate | ReplicaServiceTemplate is a `Service` template only for replica mysqld instances. | *[ServiceTemplate](#servicetemplate) | false |
 | mysqlConfigMapName | MySQLConfigMapName is a `ConfigMap` name of MySQL config. | *string | false |
 | replicationSourceSecretName | ReplicationSourceSecretName is a `Secret` name which contains replication source info. If this field is given, the `MySQLCluster` works as an intermediate primary. | *string | false |
 | collectors | Collectors is the list of collector flag names of mysqld_exporter. If this field is not empty, MOCO adds mysqld_exporter as a sidecar to collect and export mysqld metrics in Prometheus format.\n\nSee https://github.com/prometheus/mysqld_exporter/blob/master/README.md#collector-flags for flag names.\n\nExample: [\"engine_innodb_status\", \"info_schema.innodb_metrics\"] | []string | false |
@@ -181,7 +183,7 @@ ServiceTemplate defines the desired spec and annotations of Service
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | metadata | Standard object's metadata.  Only `annotations` and `labels` are valid. | [ObjectMeta](#objectmeta) | false |
-| spec | Spec is the ServiceSpec | *[corev1.ServiceSpec](https://pkg.go.dev/k8s.io/api/core/v1#ServiceSpec) | false |
+| spec | Spec is the ServiceSpec. | *[corev1.ServiceSpec](https://pkg.go.dev/k8s.io/api/core/v1#ServiceSpec) | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/onsi/ginkgo v1.16.4
-	github.com/onsi/gomega v1.13.0
+	github.com/onsi/gomega v1.16.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -505,6 +505,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
+github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
+github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=


### PR DESCRIPTION
## Motivation

In our Kubernetes cluster, we can automatically set desired external DNS name to the Service by annotating `external-dns.alpha.kubernetes.io/hostname`.

We want to set different annotations to the Service for primary instance and the Service for replica instances.

## How

As a patch for `serviceTemplate`, `primaryServiceTemplate` and `replicaServiceTemplate` can be specified in the manifest. They will be merged into the `serviceTemplate` applied to the corresponding service and applied in the reconciliation loop.

## Matter of concern

The merging of `serviceTemplate` and `primaryServiceTemplate` / `replicaServiceTemplate` is implemented by `DeepCopyInto`. This behavior may confuse kustomize users.