### PR TITLE
Remove unnecesary error message

### DIFF
--- a/cmd/kubectl-moco/cmd/root.go
+++ b/cmd/kubectl-moco/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	"github.com/cybozu-go/moco"
@@ -87,7 +86,6 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	defer klog.Flush()
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
`kubectl-moco` prints an error message twice.

```
$ ./bin/kubectl-moco credential hoge
Error: secrets "moco-hoge" not found
secrets "moco-hoge" not found
```

If an error occurs, it will be printed by `spf13/cobra`.
So we need not print the error.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>