### PR TITLE
Fixed a bug in decidePartSize calculation

### DIFF
--- a/pkg/bucket/s3.go
+++ b/pkg/bucket/s3.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	// DefaultPartSize is the default part size used for Bucket.Put method.
-	DefaultPartSize = 128 << 20
+	// PartSizeUnit is the unit of part size used for Bucket.Put method.
+	PartSizeUnit = 128 << 20
 
 	// UploadParts is the number of parts in a multi-part upload on Amazon S3.
-	UploadParts = 5000
+	UploadParts = 4 << 10
 )
 
 // WithCredentials specifies a credential provider.
@@ -136,10 +136,7 @@ func (b s3Bucket) List(ctx context.Context, prefix string) ([]string, error) {
 
 func decidePartSize(objectSize int64) int64 {
 	var partSize int64
-	if objectSize <= DefaultPartSize*UploadParts {
-		return DefaultPartSize
-	}
-	partSize = objectSize / UploadParts
-	partSize = (100 << 20) * ((partSize / (100 << 20)) + 1) // Round up to the nearest 100 MiB.
+	partSize = (objectSize + UploadParts - 1) / UploadParts                  // Round up the result of dividing objectSize by uploadPart.
+	partSize = ((partSize + PartSizeUnit - 1) / PartSizeUnit) * PartSizeUnit // Round up to the nearest PartSizeUnit.
 	return partSize
 }

--- a/pkg/bucket/s3.go
+++ b/pkg/bucket/s3.go
@@ -136,10 +136,10 @@ func (b s3Bucket) List(ctx context.Context, prefix string) ([]string, error) {
 
 func decidePartSize(objectSize int64) int64 {
 	var partSize int64
-	if objectSize <= DefaultPartSize {
+	if objectSize <= DefaultPartSize*UploadParts {
 		return DefaultPartSize
 	}
 	partSize = objectSize / UploadParts
-	partSize = (100 << 20) * ((partSize / 100 << 20) + 1) // Round up to the nearest 100 MiB.
+	partSize = (100 << 20) * ((partSize / (100 << 20)) + 1) // Round up to the nearest 100 MiB.
 	return partSize
 }

--- a/pkg/bucket/s3_test.go
+++ b/pkg/bucket/s3_test.go
@@ -139,10 +139,31 @@ var _ = Describe("S3Bucket", func() {
 	})
 
 	It("should calculate the partSize correctly", func() {
-		partSize := decidePartSize(600 << 30)
-		Expect(partSize).Should(BeNumerically("==", DefaultPartSize))
+		partSize := decidePartSize(0)
+		Expect(partSize).Should(BeNumerically("==", 0))
 
-		partSize = decidePartSize(700 << 30)
-		Expect(partSize).Should(BeNumerically("==", 200<<20))
+		partSize = decidePartSize(1)
+		Expect(partSize).Should(BeNumerically("==", PartSizeUnit))
+
+		partSize = decidePartSize(50)
+		Expect(partSize).Should(BeNumerically("==", PartSizeUnit))
+
+		partSize = decidePartSize(PartSizeUnit*UploadParts - 1)
+		Expect(partSize).Should(BeNumerically("==", PartSizeUnit))
+
+		partSize = decidePartSize(PartSizeUnit * UploadParts)
+		Expect(partSize).Should(BeNumerically("==", PartSizeUnit))
+
+		partSize = decidePartSize(PartSizeUnit*UploadParts + 1)
+		Expect(partSize).Should(BeNumerically("==", PartSizeUnit*2))
+
+		partSize = decidePartSize(PartSizeUnit*2*UploadParts - 1)
+		Expect(partSize).Should(BeNumerically("==", PartSizeUnit*2))
+
+		partSize = decidePartSize(PartSizeUnit * 2 * UploadParts)
+		Expect(partSize).Should(BeNumerically("==", PartSizeUnit*2))
+
+		partSize = decidePartSize(PartSizeUnit*2*UploadParts + 1)
+		Expect(partSize).Should(BeNumerically("==", PartSizeUnit*3))
 	})
 })

--- a/pkg/bucket/s3_test.go
+++ b/pkg/bucket/s3_test.go
@@ -137,4 +137,12 @@ var _ = Describe("S3Bucket", func() {
 
 		fmt.Println(string(data))
 	})
+
+	It("should calculate the partSize correctly", func() {
+		partSize := decidePartSize(600 << 30)
+		Expect(partSize).Should(BeNumerically("==", DefaultPartSize))
+
+		partSize = decidePartSize(700 << 30)
+		Expect(partSize).Should(BeNumerically("==", 200<<20))
+	})
 })


### PR DESCRIPTION
There are several bugs in decidePartSize:
  - If objectSize is less than **DefaultPartSize*UploadParts**, DefaultPartSize should be returned.
  https://github.com/cybozu-go/moco/blob/c9013554e92fbc97f4d29b0beb67413b16484ab9/pkg/bucket/s3.go#L139
  - Parentheses are required for shift operations.
  https://github.com/cybozu-go/moco/blob/c9013554e92fbc97f4d29b0beb67413b16484ab9/pkg/bucket/s3.go#L143

Added unittest to decidePartSize.