### PR TITLE
Stop using Reconcile's context for ClusterManager

### DIFF
--- a/clustering/manager.go
+++ b/clustering/manager.go
@@ -23,8 +23,8 @@ import (
 //
 // This interface is meant to be used by MySQLClusterReconciler.
 type ClusterManager interface {
-	Update(context.Context, types.NamespacedName)
-	UpdateNoStart(context.Context, types.NamespacedName)
+	Update(types.NamespacedName)
+	UpdateNoStart(types.NamespacedName)
 	Stop(types.NamespacedName)
 	StopAll()
 }
@@ -59,15 +59,15 @@ type clusterManager struct {
 	wg sync.WaitGroup
 }
 
-func (m *clusterManager) Update(ctx context.Context, name types.NamespacedName) {
-	m.update(ctx, name, false)
+func (m *clusterManager) Update(name types.NamespacedName) {
+	m.update(name, false)
 }
 
-func (m *clusterManager) UpdateNoStart(ctx context.Context, name types.NamespacedName) {
-	m.update(ctx, name, true)
+func (m *clusterManager) UpdateNoStart(name types.NamespacedName) {
+	m.update(name, true)
 }
 
-func (m *clusterManager) update(ctx context.Context, name types.NamespacedName, noStart bool) {
+func (m *clusterManager) update(name types.NamespacedName, noStart bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -81,7 +81,7 @@ func (m *clusterManager) update(ctx context.Context, name types.NamespacedName, 
 		return
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 
 	p = newManagerProcess(m.client, m.reader, m.recorder, m.dbf, m.agentf, name, m.log.WithName(key), cancel)
 	m.wg.Add(1)

--- a/clustering/manager.go
+++ b/clustering/manager.go
@@ -55,6 +55,7 @@ type clusterManager struct {
 
 	mu        sync.Mutex
 	processes map[string]*managerProcess
+	stopped   bool
 
 	wg sync.WaitGroup
 }
@@ -70,6 +71,10 @@ func (m *clusterManager) UpdateNoStart(name types.NamespacedName) {
 func (m *clusterManager) update(name types.NamespacedName, noStart bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.stopped {
+		return
+	}
 
 	key := name.String()
 	p, ok := m.processes[key]
@@ -115,4 +120,5 @@ func (m *clusterManager) StopAll() {
 	m.processes = nil
 
 	m.wg.Wait()
+	m.stopped = true
 }

--- a/clustering/manager_test.go
+++ b/clustering/manager_test.go
@@ -161,7 +161,7 @@ var _ = Describe("manager", func() {
 
 		cluster, err := testGetCluster(ctx)
 		Expect(err).NotTo(HaveOccurred())
-		cm.Update(ctx, client.ObjectKeyFromObject(cluster))
+		cm.Update(client.ObjectKeyFromObject(cluster))
 
 		Eventually(func() error {
 			cluster, err = testGetCluster(ctx)
@@ -283,7 +283,7 @@ var _ = Describe("manager", func() {
 
 		cluster, err := testGetCluster(ctx)
 		Expect(err).NotTo(HaveOccurred())
-		cm.Update(ctx, client.ObjectKeyFromObject(cluster))
+		cm.Update(client.ObjectKeyFromObject(cluster))
 		defer func() {
 			cm.Stop(client.ObjectKeyFromObject(cluster))
 			time.Sleep(400 * time.Millisecond)
@@ -632,7 +632,7 @@ var _ = Describe("manager", func() {
 
 		cluster, err := testGetCluster(ctx)
 		Expect(err).NotTo(HaveOccurred())
-		cm.Update(ctx, client.ObjectKeyFromObject(cluster))
+		cm.Update(client.ObjectKeyFromObject(cluster))
 		defer func() {
 			cm.Stop(client.ObjectKeyFromObject(cluster))
 			time.Sleep(400 * time.Millisecond)
@@ -838,7 +838,7 @@ var _ = Describe("manager", func() {
 			return k8sClient.Status().Update(ctx, cluster)
 		}).Should(Succeed())
 
-		cm.Update(ctx, client.ObjectKeyFromObject(cluster))
+		cm.Update(client.ObjectKeyFromObject(cluster))
 
 		Eventually(func() interface{} {
 			return ms.backupTimestamp

--- a/controllers/mock_test.go
+++ b/controllers/mock_test.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"context"
 	"sync"
 
 	"github.com/cybozu-go/moco/clustering"
@@ -16,14 +15,14 @@ type mockManager struct {
 
 var _ clustering.ClusterManager = &mockManager{}
 
-func (m *mockManager) Update(ctx context.Context, key types.NamespacedName) {
+func (m *mockManager) Update(key types.NamespacedName) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.clusters[key.String()] = struct{}{}
 }
 
-func (m *mockManager) UpdateNoStart(ctx context.Context, key types.NamespacedName) {
+func (m *mockManager) UpdateNoStart(key types.NamespacedName) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -239,7 +239,7 @@ func (r *MySQLClusterReconciler) reconcileV1(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	r.ClusterManager.Update(ctx, client.ObjectKeyFromObject(cluster))
+	r.ClusterManager.Update(client.ObjectKeyFromObject(cluster))
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/pod_watcher.go
+++ b/controllers/pod_watcher.go
@@ -72,7 +72,7 @@ func (r *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	log.Info("detected mysql pod deletion", "name", pod.Name)
-	r.ClusterManager.UpdateNoStart(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: ref.Name})
+	r.ClusterManager.UpdateNoStart(types.NamespacedName{Namespace: pod.Namespace, Name: ref.Name})
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
The context passed as a `Recincle()`'s argument is short-lived.
It is not good for the ClusterManager to depend on the short-lived context.

Regardless of the context, the ClusterManager's goroutines will be stopped here.
https://github.com/cybozu-go/moco/blob/v0.10.9/cmd/moco-controller/cmd/run.go#L86
So we need not add the another deletion function.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>