### PR TITLE
Fixed panic when migrating to SSA.

### DIFF
--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -161,14 +161,9 @@ func (r *MySQLClusterReconciler) makeV1AgentContainer(cluster *mocov1beta2.MySQL
 }
 
 func (r *MySQLClusterReconciler) makeV1SlowQueryLogContainer(sts *appsv1ac.StatefulSetApplyConfiguration, force bool) *corev1ac.ContainerApplyConfiguration {
-	isNotNil := func(sts *appsv1ac.StatefulSetApplyConfiguration) bool {
-		if sts == nil || sts.Spec == nil || sts.Spec.Template == nil || sts.Spec.Template.Spec == nil {
-			return false
-		}
-		return true
-	}
+	stsINotNil := (sts != nil && sts.Spec != nil && sts.Spec.Template != nil && sts.Spec.Template.Spec != nil)
 
-	if !force && isNotNil(sts) {
+	if !force && stsINotNil {
 		for _, c := range sts.Spec.Template.Spec.Containers {
 			if *c.Name == constants.SlowQueryLogAgentContainerName {
 				return &c

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -161,7 +161,14 @@ func (r *MySQLClusterReconciler) makeV1AgentContainer(cluster *mocov1beta2.MySQL
 }
 
 func (r *MySQLClusterReconciler) makeV1SlowQueryLogContainer(sts *appsv1ac.StatefulSetApplyConfiguration, force bool) *corev1ac.ContainerApplyConfiguration {
-	if !force {
+	isNotNil := func(sts *appsv1ac.StatefulSetApplyConfiguration) bool {
+		if sts == nil || sts.Spec == nil || sts.Spec.Template == nil || sts.Spec.Template.Spec == nil {
+			return false
+		}
+		return true
+	}
+
+	if !force && isNotNil(sts) {
 		for _, c := range sts.Spec.Template.Spec.Containers {
 			if *c.Name == constants.SlowQueryLogAgentContainerName {
 				return &c


### PR DESCRIPTION
MOCO refers to the current spec of the StatefulSet when creating the SlowQueryLogContainer.

https://github.com/cybozu-go/moco/blob/abdde66ee673c7232b8c22b7396ed6665dc69ccb/controllers/mysqlcluster_controller.go#L717-L724

When I introduced server-side-apply, we used ExtractStatefulSet to get the applyconfigration, but the first time we server-side-apply, it returns an empty StatefulSetApplyConfigration because the field manager does not exist.

```
"{\"kind\":\"StatefulSet\",\"apiVersion\":\"apps/v1\",\"metadata\":{\"name\":\"moco-fuga\",\"namespace\":\"default\"}}"
```

The resulting spec was nil, which caused a panic.

https://github.com/cybozu-go/moco/blob/abdde66ee673c7232b8c22b7396ed6665dc69ccb/controllers/mysql_container.go#L164-L170

This PullRequest adds a nil check to avoid panic and to make the first time apply without field manager behave the same as when `force=true` is specified.