### PR TITLE
Validate that container name is non-nil in validation webhook

### DIFF
--- a/api/v1beta2/mysqlcluster_types.go
+++ b/api/v1beta2/mysqlcluster_types.go
@@ -152,6 +152,7 @@ func (s MySQLClusterSpec) validateCreate() field.ErrorList {
 	mysqldIndex := -1
 	for i, container := range s.PodTemplate.Spec.Containers {
 		if container.Name == nil {
+			allErrs = append(allErrs, field.Forbidden(pp.Index(i), "container name is required"))
 			continue
 		}
 
@@ -192,6 +193,7 @@ func (s MySQLClusterSpec) validateCreate() field.ErrorList {
 	pp = p.Child("initContainers")
 	for i, container := range s.PodTemplate.Spec.InitContainers {
 		if container.Name == nil {
+			allErrs = append(allErrs, field.Forbidden(pp.Index(i), "init container name is required"))
 			continue
 		}
 

--- a/api/v1beta2/mysqlcluster_webhook_test.go
+++ b/api/v1beta2/mysqlcluster_webhook_test.go
@@ -117,6 +117,24 @@ var _ = Describe("MySQLCluster Webhook", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should deny without container name", func() {
+		r := makeMySQLCluster()
+		spec := (corev1ac.PodSpecApplyConfiguration)(r.Spec.PodTemplate.Spec)
+		spec.WithContainers(corev1ac.Container().WithImage("image:dev"))
+		r.Spec.PodTemplate.Spec = (mocov1beta2.PodSpecApplyConfiguration)(spec)
+		err := k8sClient.Create(ctx, r)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should deny without init container name", func() {
+		r := makeMySQLCluster()
+		spec := (corev1ac.PodSpecApplyConfiguration)(r.Spec.PodTemplate.Spec)
+		spec.WithInitContainers(corev1ac.Container().WithImage("image:dev"))
+		r.Spec.PodTemplate.Spec = (mocov1beta2.PodSpecApplyConfiguration)(spec)
+		err := k8sClient.Create(ctx, r)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("should deny mysqld container using reserved port", func() {
 		for _, port := range []*corev1ac.ContainerPortApplyConfiguration{
 			corev1ac.ContainerPort().WithContainerPort(constants.MySQLPort),


### PR DESCRIPTION
refs: #306 

Validate that the container name is non-nil with the validation webhook.
This is a follow-up to the validation that disappeared from the CRD spec when SSA was introduced.