### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.go-version }}
     - run: make release-build
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.go-version }}
     - run: make test
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.go-version }}
     - run: make setup
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.go-version }}
     - run: |
@@ -66,7 +66,7 @@ jobs:
     - run: make logs
       working-directory: e2e
       if: always()
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: logs-${{ matrix.k8s-version }}-${{ matrix.mysql-version }}.tar.gz
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go-version }}
       - run: |
@@ -95,7 +95,7 @@ jobs:
       - run: make logs
         working-directory: e2e
         if: always()
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: logs-${{ matrix.k8s-version }}-${{ matrix.mysql-version }}.tar.gz
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.go-version }}
     - run: |
@@ -120,7 +120,7 @@ jobs:
     - run: make logs
       working-directory: e2e
       if: always()
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: logs-upgrade.tar.gz

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Packaging the chart
         run: helm package ./charts/moco/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: helm-charts
           path: ./moco-*.tgz
@@ -50,7 +50,7 @@ jobs:
         with:
           version: v3.6.3
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: helm-charts
 

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -16,12 +16,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.2.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: make book
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: book
         path: docs/book
@@ -26,7 +26,7 @@ jobs:
         ref: gh-pages
       # ignore helm chart index file and chart archive file.
     - run: ls | grep -v -E 'index.yaml|moco-.*\.tgz' | xargs rm -rf
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: book
     - run: ls -R

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.go-version }}
     - name: GoReleaser
@@ -42,5 +42,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Update new version in krew-index
-      # v0.0.40 https://github.com/rajatjindal/krew-release-bot/releases/tag/v0.0.40
-      uses: rajatjindal/krew-release-bot@56925b62bacc2c652114d66a8256faaf0bf89fa9
+      # v0.0.42 https://github.com/rajatjindal/krew-release-bot/releases/tag/v0.0.42
+      uses: rajatjindal/krew-release-bot@ba5e167fbd1526240f5f5d2eaf1ec573fc5942de

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ book: mdbook
 .PHONY: check-generate
 check-generate:
 	$(MAKE) manifests generate apidoc
+	go mod tidy
 	git diff --exit-code --name-only
 
 .PHONY: envtest

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/go-logr/stdr v1.2.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.6
-	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/gofuzz v1.2.0
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0


### PR DESCRIPTION
- Run `go mod tidy` in `check-generate` target.
- Update some actions.

Currently the following actions are used.
```
$ find .github/* -type f | xargs grep uses: | cut -d':' -f 3 | sort -u
 actions/checkout@v2
 actions/download-artifact@v3
 actions/setup-go@v3
 actions/setup-python@v3
 actions/upload-artifact@v3
 azure/setup-helm@v1
 goreleaser/goreleaser-action@v2
 helm/chart-testing-action@v2.2.1
 helm/kind-action@v1.2.0
 rajatjindal/krew-release-bot@ba5e167fbd1526240f5f5d2eaf1ec573fc5942de
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>