### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2022-04-22
+
+### Added
+- Allow users to customize containers resources (#394, #395)
+- Clarify a known issue about multi-threaded replication (#400, #401)
+
+### Changed
+- Update mysqld_exporter and Fluent Bit (#402)
+- Support k8s 1.23 (#399)
+- Update actions (#398)
+
+### Fixed
+- Fix broken helm chart (#397)
+
 ## [0.11.1] - 2022-03-16
 
 ### Changed
@@ -311,7 +325,8 @@ The `MySQLCluster` created by MOCO `< v0.5.0` has no compatibility with `>= v0.5
 
 - Bootstrap a vanilla MySQL cluster with no replicas (#2).
 
-[Unreleased]: https://github.com/cybozu-go/moco/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/cybozu-go/moco/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/cybozu-go/moco/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/cybozu-go/moco/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/cybozu-go/moco/compare/v0.10.9...v0.11.0
 [0.10.9]: https://github.com/cybozu-go/moco/compare/v0.10.8...v0.10.9

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 
 images:
 - name: ghcr.io/cybozu-go/moco
-  newTag: 0.11.1
+  newTag: 0.12.0

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package moco
 
 const (
 	// Version is the MOCO version
-	Version = "0.11.1"
+	Version = "0.12.0"
 
 	// FluentBitImage is the image for slow-log sidecar container.
 	FluentBitImage = "quay.io/cybozu/fluent-bit:1.9.1.1"


### PR DESCRIPTION
I will write the following description to the release page.

```
Additional Features:
From this release, MOCO automatically sets the resource requests and limits for system containers of MySQL Pods.
This feature will allow you to change the MySQL Pod's QoS by setting the `resources` of the `mysqld` container.

You can overwrite the default resource settings of system containers.
Please read the following document for details.

[Customize default container](./docs/customize-system-container.md)

Breaking Changes:
This release updates the [mysqld_exporter](https://github.com/prometheus/mysqld_exporter) from v0.13.0 to 0.14.0.
Along with this update, some metrics' names have been changed.
Please refer to the following page for details.

https://github.com/prometheus/mysqld_exporter/releases/tag/v0.14.0
```