### PR TITLE
Make sure partial_revokes is enabled

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -125,6 +125,8 @@ The complete reference of MySQLCluster is [`crd_mysqlcluster.md`](crd_mysqlclust
 
 Let's call the source mysqld instance _donor_.
 
+First, make sure `partial_revokes` is enabled **on the donor**; Replicating data from the donor with `partial_revokes` disabled will [result in replication inconsistencies or errors](https://dev.mysql.com/doc/refman/8.0/en/partial-revokes.html#partial-revokes-replication) since MOCO uses `partial_revokes` functionality.
+
 We use [the clone plugin][CLONE] to copy the whole data quickly.
 After the cloning, MOCO needs to create some user accounts and install plugins.
 


### PR DESCRIPTION
We encountered the following error when executing GRANT statements on the donor while replicating data from the donor with `partial_revokes` disabled to the MySQLCluster by MOCO.

```
Error 'Either some of the authorization IDs in the AS clause are invalid or the current user lacks privileges to execute the statement.' on query. Default database: ''. Query: 'GRANT ALL PRIVILEGES ON *.* TO 'clone-init'@'localhost' WITH GRANT OPTION AS 'skip-grants user'@'skip-grants host' WITH ROLE NONE'
```

[MySQL 8.0 reference manual](https://dev.mysql.com/doc/refman/8.0/en/partial-revokes.html#partial-revokes-replication) says 'In replication scenarios, if partial_revokes is enabled on any host, it must be enabled on all hosts'.