### PR TITLE
Validate storage class supports volume size expansion

### DIFF
--- a/api/v1beta2/mysqlcluster_webhook.go
+++ b/api/v1beta2/mysqlcluster_webhook.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -18,57 +19,66 @@ import (
 func (r *MySQLCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
+		WithValidator(&mySQLClusterAdmission{client: mgr.GetAPIReader()}).
+		WithDefaulter(&mySQLClusterAdmission{client: mgr.GetAPIReader()}).
 		Complete()
+}
+
+type mySQLClusterAdmission struct {
+	client client.Reader
 }
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 //+kubebuilder:webhook:path=/mutate-moco-cybozu-com-v1beta2-mysqlcluster,mutating=true,failurePolicy=fail,sideEffects=None,matchPolicy=Equivalent,groups=moco.cybozu.com,resources=mysqlclusters,verbs=create,versions=v1beta2,name=mmysqlcluster.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Defaulter = &MySQLCluster{}
+var _ webhook.CustomDefaulter = &mySQLClusterAdmission{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *MySQLCluster) Default() {
-	controllerutil.AddFinalizer(r, constants.MySQLClusterFinalizer)
+func (a *mySQLClusterAdmission) Default(ctx context.Context, obj runtime.Object) error {
+	cluster := obj.(*MySQLCluster)
 
-	if r.Spec.ServerIDBase == 0 {
+	controllerutil.AddFinalizer(cluster, constants.MySQLClusterFinalizer)
+
+	if cluster.Spec.ServerIDBase == 0 {
 		buf := make([]byte, 4) // server_id is a uint32 value
 		_, err := rand.Read(buf)
 		if err != nil {
 			panic(err)
 		}
-		r.Spec.ServerIDBase = int32(binary.LittleEndian.Uint32(buf)&uint32(math.MaxInt32>>1)) + 1
+		cluster.Spec.ServerIDBase = int32(binary.LittleEndian.Uint32(buf)&uint32(math.MaxInt32>>1)) + 1
 	}
+
+	return nil
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-moco-cybozu-com-v1beta2-mysqlcluster,mutating=false,failurePolicy=fail,sideEffects=None,matchPolicy=Equivalent,groups=moco.cybozu.com,resources=mysqlclusters,verbs=create;update,versions=v1beta2,name=vmysqlcluster.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &MySQLCluster{}
+var _ webhook.CustomValidator = &mySQLClusterAdmission{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *MySQLCluster) ValidateCreate() error {
-	errs := r.Spec.validateCreate()
+func (a *mySQLClusterAdmission) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	cluster := obj.(*MySQLCluster)
+
+	errs := cluster.Spec.validateCreate()
 	if len(errs) == 0 {
 		return nil
 	}
 
-	return apierrors.NewInvalid(schema.GroupKind{Group: GroupVersion.Group, Kind: "MySQLCluster"}, r.Name, errs)
+	return apierrors.NewInvalid(schema.GroupKind{Group: GroupVersion.Group, Kind: "MySQLCluster"}, cluster.Name, errs)
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *MySQLCluster) ValidateUpdate(old runtime.Object) error {
-	ctx := context.Background()
+func (a *mySQLClusterAdmission) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	oldCluster := oldObj.(*MySQLCluster)
+	newCluster := newObj.(*MySQLCluster)
 
-	errs := r.Spec.validateUpdate(ctx, apiReader, old.(*MySQLCluster).Spec)
+	errs := newCluster.Spec.validateUpdate(ctx, a.client, oldCluster.Spec)
 	if len(errs) == 0 {
 		return nil
 	}
 
-	return apierrors.NewInvalid(schema.GroupKind{Group: GroupVersion.Group, Kind: "MySQLCluster"}, r.Name, errs)
+	return apierrors.NewInvalid(schema.GroupKind{Group: GroupVersion.Group, Kind: "MySQLCluster"}, newCluster.Name, errs)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *MySQLCluster) ValidateDelete() error {
+func (a *mySQLClusterAdmission) ValidateDelete(ctx context.Context, obj runtime.Object) error {
 	return nil
 }

--- a/api/v1beta2/mysqlcluster_webhook.go
+++ b/api/v1beta2/mysqlcluster_webhook.go
@@ -1,6 +1,7 @@
 package v1beta2
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"math"
@@ -57,7 +58,9 @@ func (r *MySQLCluster) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *MySQLCluster) ValidateUpdate(old runtime.Object) error {
-	errs := r.Spec.validateUpdate(old.(*MySQLCluster).Spec)
+	ctx := context.Background()
+
+	errs := r.Spec.validateUpdate(ctx, apiReader, old.(*MySQLCluster).Spec)
 	if len(errs) == 0 {
 		return nil
 	}

--- a/api/v1beta2/mysqlcluster_webhook_test.go
+++ b/api/v1beta2/mysqlcluster_webhook_test.go
@@ -453,17 +453,45 @@ var _ = Describe("MySQLCluster Webhook", func() {
 
 	It("should allow storage size expansion", func() {
 		r := makeMySQLCluster()
+		r.Spec.VolumeClaimTemplates = make([]mocov1beta2.PersistentVolumeClaim, 2)
+
+		r.Spec.VolumeClaimTemplates[0] = mocov1beta2.PersistentVolumeClaim{
+			ObjectMeta: mocov1beta2.ObjectMeta{
+				Name: "mysql-data",
+			},
+			Spec: mocov1beta2.PersistentVolumeClaimSpecApplyConfiguration(
+				*corev1ac.PersistentVolumeClaimSpec().
+					WithStorageClassName("default").
+					WithResources(corev1ac.ResourceRequirements().
+						WithRequests(corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						}),
+					),
+			),
+		}
+
+		r.Spec.VolumeClaimTemplates[1] = mocov1beta2.PersistentVolumeClaim{
+			ObjectMeta: mocov1beta2.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: mocov1beta2.PersistentVolumeClaimSpecApplyConfiguration(
+				*corev1ac.PersistentVolumeClaimSpec().
+					WithStorageClassName("not-support-volume-expansion").
+					WithResources(corev1ac.ResourceRequirements().
+						WithRequests(corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						}),
+					),
+			),
+		}
+
 		err := k8sClient.Create(ctx, r)
 		Expect(err).NotTo(HaveOccurred())
 
-		r.Spec.VolumeClaimTemplates[0].Spec = mocov1beta2.PersistentVolumeClaimSpecApplyConfiguration(
-			*corev1ac.PersistentVolumeClaimSpec().
-				WithStorageClassName("default").
-				WithResources(corev1ac.ResourceRequirements().
-					WithRequests(corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("10Gi"),
-					}),
-				),
+		r.Spec.VolumeClaimTemplates[0].Spec.Resources.WithRequests(
+			corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
 		)
 
 		err = k8sClient.Update(ctx, r)
@@ -491,17 +519,45 @@ var _ = Describe("MySQLCluster Webhook", func() {
 
 	It("should deny storage size expansion for not support volume expansion storage class", func() {
 		r := makeMySQLCluster()
+		r.Spec.VolumeClaimTemplates = make([]mocov1beta2.PersistentVolumeClaim, 2)
+
+		r.Spec.VolumeClaimTemplates[0] = mocov1beta2.PersistentVolumeClaim{
+			ObjectMeta: mocov1beta2.ObjectMeta{
+				Name: "mysql-data",
+			},
+			Spec: mocov1beta2.PersistentVolumeClaimSpecApplyConfiguration(
+				*corev1ac.PersistentVolumeClaimSpec().
+					WithStorageClassName("default").
+					WithResources(corev1ac.ResourceRequirements().
+						WithRequests(corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						}),
+					),
+			),
+		}
+
+		r.Spec.VolumeClaimTemplates[1] = mocov1beta2.PersistentVolumeClaim{
+			ObjectMeta: mocov1beta2.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: mocov1beta2.PersistentVolumeClaimSpecApplyConfiguration(
+				*corev1ac.PersistentVolumeClaimSpec().
+					WithStorageClassName("not-support-volume-expansion").
+					WithResources(corev1ac.ResourceRequirements().
+						WithRequests(corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						}),
+					),
+			),
+		}
+
 		err := k8sClient.Create(ctx, r)
 		Expect(err).NotTo(HaveOccurred())
 
-		r.Spec.VolumeClaimTemplates[0].Spec = mocov1beta2.PersistentVolumeClaimSpecApplyConfiguration(
-			*corev1ac.PersistentVolumeClaimSpec().
-				WithStorageClassName("not-support-volume-expansion").
-				WithResources(corev1ac.ResourceRequirements().
-					WithRequests(corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("10Gi"),
-					}),
-				),
+		r.Spec.VolumeClaimTemplates[1].Spec.Resources.WithRequests(
+			corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
 		)
 
 		err = k8sClient.Update(ctx, r)

--- a/api/v1beta2/webhook_suite_test.go
+++ b/api/v1beta2/webhook_suite_test.go
@@ -16,6 +16,8 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,6 +52,8 @@ var _ = BeforeSuite(func() {
 	err = mocov1beta2.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = clientgoscheme.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/265

depends: https://github.com/cybozu-go/moco/pull/417

Currently, does not check to see if the storage class supports volume expansion when the PVC storage size is increased.
validation webhook does not allow the storage size to be reduced, so there is no way for the user to recover from this situation.

Use validation webhooks to see if your storage class supports volume expansion and reject the request if it doesn't.