### PR TITLE
Add statefulset invalid error metrics

### DIFF
--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -968,6 +968,9 @@ func (r *MySQLClusterReconciler) reconcileV1StatefulSet(ctx context.Context, req
 		if needRecreate {
 			metrics.StatefulSetRecreateErrorTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
 		}
+		if apierrors.IsInvalid(err) {
+			metrics.StatefulSetInvalidErrorTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
+		}
 		return fmt.Errorf("failed to reconcile stateful set: %w", err)
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,6 +26,7 @@ var (
 	VolumeResizedErrorTotal       *prometheus.CounterVec
 	StatefulSetRecreateTotal      *prometheus.CounterVec
 	StatefulSetRecreateErrorTotal *prometheus.CounterVec
+	StatefulSetInvalidErrorTotal  *prometheus.CounterVec
 )
 
 // Backup related metrics
@@ -191,4 +192,12 @@ func Register(registry prometheus.Registerer) {
 		Help:      "The number of failed StatefulSet recreates",
 	}, []string{"name", "namespace"})
 	registry.MustRegister(StatefulSetRecreateErrorTotal)
+
+	StatefulSetInvalidErrorTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: clusteringSubsystem,
+		Name:      "statefulset_invalid_errors_total",
+		Help:      "The number of invalid error was returned updating a StatefulSet",
+	}, []string{"name", "namespace"})
+	registry.MustRegister(StatefulSetInvalidErrorTotal)
 }


### PR DESCRIPTION
refs: #265

Added metrics to show re-creation counts when StatefulSet re-creation is supported.

This Pull Request adds metrics for the number of times an update of the immutable field in the StatefulSet has resulted in an error.
This allows users to detect unrecoverable StatefulSet update errors.