### PR TITLE
Fix wrong issuer name in helm chart

### DIFF
--- a/charts/moco/templates/certificate.yaml
+++ b/charts/moco/templates/certificate.yaml
@@ -9,7 +9,7 @@ spec:
   commonName: moco-controller
   issuerRef:
     kind: Issuer
-    name: {{ template "moco.fullname" . }}-grpc-issuer
+    name: moco-grpc-issuer
   secretName: moco-controller-grpc
   usages:
     - digital signature

--- a/charts/moco/templates/issuer.yaml
+++ b/charts/moco/templates/issuer.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ template "moco.fullname" . }}-grpc-issuer
+  name: moco-grpc-issuer
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "moco.labels" . | nindent 4 }}


### PR DESCRIPTION
fix #426

If you specify a name other than `moco` in helm install, `<specified name>-grpc-issuer` will be applied.
However, `moco-grpc-issuer` is referenced in moco-controller.
https://github.com/cybozu-go/moco/blob/ae0c853b7ac893fd6c3bfbb819f2b57d7d5ee97e/controllers/certificate_tmpl.yaml#L16