### PR TITLE
Delete cluster after E2E

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -47,7 +47,7 @@ endif
 .PHONY: test
 test:
 	env PATH="$$(pwd)/../bin:$$PATH" RUN_E2E=1 \
-		go test -v -race -timeout 15m . -ginkgo.progress -ginkgo.v -ginkgo.failFast
+		go test -v -race -timeout 20m . -ginkgo.progress -ginkgo.v -ginkgo.failFast
 
 .PHONY: test-upgrade
 test-upgrade:

--- a/e2e/backup_test.go
+++ b/e2e/backup_test.go
@@ -163,4 +163,8 @@ var _ = Context("backup", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(count).To(Equal(2))
 	})
+
+	It("should delete clusters", func() {
+		kubectlSafe(nil, "delete", "-n", "backup", "mysqlclusters", "--all")
+	})
 })

--- a/e2e/pvc_test.go
+++ b/e2e/pvc_test.go
@@ -194,4 +194,8 @@ var _ = Context("pvc_test", func() {
 		Expect(stsMetric).NotTo(BeNil())
 		Expect(stsMetric.GetCounter().GetValue()).To(BeNumerically("==", 1))
 	})
+
+	It("should delete clusters", func() {
+		kubectlSafe(nil, "delete", "-n", "pvc", "mysqlclusters", "--all")
+	})
 })

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -14,7 +14,7 @@ func TestE2e(t *testing.T) {
 		t.Skip("no RUN_E2E environment variable")
 	}
 	RegisterFailHandler(Fail)
-	SetDefaultEventuallyTimeout(3 * time.Minute)
+	SetDefaultEventuallyTimeout(5 * time.Minute)
 	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
 	RunSpecs(t, "E2e Suite")
 }

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -148,4 +148,8 @@ var _ = Context("upgrade", func() {
 			return errors.New("no health condition")
 		}).Should(Succeed())
 	})
+
+	It("should delete clusters", func() {
+		kubectlSafe(nil, "delete", "-n", "upgrade", "mysqlclusters", "--all")
+	})
 })


### PR DESCRIPTION
Clean up resources after running E2E tests and extend the test timeout.
These changes the stability of E2E tests.

But, I'm still seeing rare test failures and I will continue to investigate.