### PR TITLE
Add helm chart values

### DIFF
--- a/charts/moco/README.md
+++ b/charts/moco/README.md
@@ -38,10 +38,14 @@ $ helm install --create-namespace --namespace moco-system moco -f values.yaml mo
 
 ## Values
 
-| Key              | Type   | Default                    | Description                   |
-| ---------------- | ------ | -------------------------- | ----------------------------- |
-| image.repository | string | `"ghcr.io/cybozu-go/moco"` | MOCO image repository to use. |
-| image.tag        | string | `{{ .Chart.AppVersion }}`  | MOCO image tag to use.        |
+| Key              | Type   | Default                                       | Description                           |
+|------------------|--------|-----------------------------------------------|---------------------------------------|
+| image.repository | string | `"ghcr.io/cybozu-go/moco"`                    | MOCO image repository to use.         |
+| image.tag        | string | `{{ .Chart.AppVersion }}`                     | MOCO image tag to use.                |
+| resources        | object | `{"requests":{"cpu":"100m","memory":"20Mi"}}` | resources used by moco-controller.    |
+| nodeSelector     | object | `{}`                                          | nodeSelector used by moco-controller. |
+| affinity         | object | `{}`                                          | affinity used by moco-controller.     |
+| tolerations      | list   | `[]`                                          | tolerations used by moco-controller.  |
 
 ## Generate Manifests
 

--- a/charts/moco/templates/deployment.yaml
+++ b/charts/moco/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: moco-controller
-  {{- include "moco.labels" . | nindent 4 }}
+    {{- include "moco.labels" . | nindent 4 }}
 spec:
   replicas: 2
   selector:
@@ -50,10 +50,10 @@ spec:
               port: health
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- with .Values.resources }}
           resources:
-            requests:
-              cpu: 100m
-              memory: 20Mi
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -68,6 +68,18 @@ spec:
         runAsNonRoot: true
       serviceAccountName: moco-controller-manager
       terminationGracePeriodSeconds: 10
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: cert
           secret:

--- a/charts/moco/values.yaml
+++ b/charts/moco/values.yaml
@@ -5,3 +5,18 @@ image:
   # image.tag -- MOCO image tag to use.
   # @default -- `{{ .Chart.AppVersion }}`
   tag:  # 0.12.1
+
+# resources -- resources used by moco-controller.
+resources:
+  requests:
+    cpu: 100m
+    memory: 20Mi
+
+# nodeSelector -- nodeSelector used by moco-controller.
+nodeSelector: {}
+
+# affinity -- affinity used by moco-controller.
+affinity: {}
+
+# tolerations -- tolerations used by moco-controller.
+tolerations: []


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/441

Add four helm values：

* `resources`
* `nodeSelector`
* `affinity`
* `tolerations`

### tests

values:

```yaml
# resources -- resources used by moco-controller.
resources:
  requests:
    cpu: 100m
    memory: 20Mi

# nodeSelector -- nodeSelector used by moco-controller.
nodeSelector:
  foo: bar

# affinity -- affinity used by moco-controller.
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
        - matchExpressions:
            - key: foo
              operator: In
              values:
                - bar

# tolerations -- tolerations used by moco-controller.
tolerations:
  - key: foo
    value: bar
    effect: NoSchedule
```

result:


```yaml
# Source: moco/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: moco-controller
  namespace: default
  labels:
    app.kubernetes.io/component: moco-controller
    helm.sh/chart: moco-0.2.3
    app.kubernetes.io/name: moco
    app.kubernetes.io/version: "0.12.1"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/component: moco-controller
      app.kubernetes.io/name: moco
  template:
    metadata:
      annotations:
        kubectl.kubernetes.io/default-container: moco-controller
      labels:
        app.kubernetes.io/component: moco-controller
        app.kubernetes.io/name: moco
    spec:
      containers:
        - env:
            - name: POD_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
          image: "ghcr.io/cybozu-go/moco:0.12.1"
          livenessProbe:
            httpGet:
              path: /healthz
              port: health
            initialDelaySeconds: 15
            periodSeconds: 20
          name: moco-controller
          ports:
            - containerPort: 9443
              name: webhook-server
              protocol: TCP
            - containerPort: 8081
              name: health
              protocol: TCP
            - containerPort: 8080
              name: metrics
              protocol: TCP
          readinessProbe:
            httpGet:
              path: /readyz
              port: health
            initialDelaySeconds: 5
            periodSeconds: 10
          resources:
            requests:
              cpu: 100m
              memory: 20Mi
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
          volumeMounts:
            - mountPath: /tmp/k8s-webhook-server/serving-certs
              name: cert
              readOnly: true
            - mountPath: /grpc-cert
              name: grpc-cert
              readOnly: true
      securityContext:
        runAsNonRoot: true
      serviceAccountName: moco-controller-manager
      terminationGracePeriodSeconds: 10
      nodeSelector:
        foo: bar
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: foo
                operator: In
                values:
                - bar
      tolerations:
        - effect: NoSchedule
          key: foo
          value: bar
      volumes:
        - name: cert
          secret:
            defaultMode: 420
            secretName: moco-controller-cert
        - name: grpc-cert
          secret:
            defaultMode: 420
            secretName: moco-controller-grpc
```

```console
$ kubectl apply -f tests.yaml --dry-run=server
deployment.apps/moco-controller created (server dry run)
```