### PR TITLE
Use reusing workflow

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Integration tests with MySQL
     strategy:
       matrix:
-        mysql-version: ["8.0.18", "8.0.28", "8.0.30"]
+        mysql-version: ["8.0.27", "8.0.28", "8.0.30"]
     uses: ./.github/workflows/dbtest.yaml
     with:
       mysql-version: ${{ matrix.mysql-version }}
@@ -42,7 +42,7 @@ jobs:
     name: Supported MySQL versions End-to-End Tests
     strategy:
       matrix:
-        mysql-version: ["8.0.18", "8.0.28", "8.0.30"]
+        mysql-version: ["8.0.27", "8.0.28", "8.0.30"]
         k8s-version: ["1.24.2"]
     uses: ./.github/workflows/e2e.yaml
     with:

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -12,7 +12,7 @@ on:
 env:
   cache-version: 1
 
-# Use only the LTS version of MySQL for E2E running in CI.
+# CI tests with the LTS version plus the latest and one previous MySQL version.
 # Other MySQL supported versions tested weekly.
 # see: weekly.yaml
 #

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -12,11 +12,11 @@ on:
 env:
   cache-version: 1
 
-# CI tests with the LTS version plus the latest and one previous MySQL version.
+# CI tests with the Cybozu internal use version plus the latest and one previous MySQL version.
 # Other MySQL supported versions tested weekly.
 # see: weekly.yaml
 #
-# NOTE: The LTS version is the version that Cybozu uses internally.
+# NOTE: Current Cybozu internal use version is 8.0.28.
 jobs:
   dbtest:
     name: Integration tests with MySQL

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -1,0 +1,71 @@
+name: E2E CI
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths-ignore: ['**.md']
+  pull_request:
+    types: [opened, synchronize]
+    paths-ignore: ['**.md']
+
+env:
+  cache-version: 1
+
+jobs:
+  dbtest:
+    name: Integration tests with MySQL
+    strategy:
+      matrix:
+        mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30"]
+    uses: ./.github/workflows/dbtest.yaml
+    with:
+      mysql-version: ${{ matrix.mysql-version }}
+
+  e2e:
+    name: Supported Kubernetes versions End-to-End Tests
+    strategy:
+      matrix:
+        mysql-version: ["8.0.30"]
+        k8s-version: ["1.22.9", "1.23.6", "1.24.2"]
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      k8s-version: ${{ matrix.k8s-version }}
+      mysql-version: ${{ matrix.mysql-version }}
+
+  e2e-mysql:
+    name: Supported MySQL versions End-to-End Tests
+    strategy:
+      matrix:
+        mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30"]
+        k8s-version: ["1.24.2"]
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      k8s-version: ${{ matrix.k8s-version }}
+      mysql-version: ${{ matrix.mysql-version }}
+
+  upgrade:
+    name: Upgrade Test
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - run: |
+          swapon > swapon.txt
+          sudo swapoff -a
+          cat swapon.txt | tail -n+2 | awk '$2=="file" {print $1}' | sudo xargs --no-run-if-empty rm
+      - run: sudo mkdir /mnt/local-path-provisioner0 /mnt/local-path-provisioner1 /mnt/local-path-provisioner2
+      - run: make start KIND_CONFIG=kind-config_actions.yaml
+        working-directory: e2e
+      - run: make test-upgrade
+        working-directory: e2e
+      - run: make logs
+        working-directory: e2e
+        if: always()
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: logs-upgrade.tar.gz
+          path: e2e/logs.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,78 +28,38 @@ jobs:
     - run: make test
     - run: make check-generate
     - run: make envtest
+
   dbtest:
     name: Integration tests with MySQL
     strategy:
       matrix:
         mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30"]
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version: ${{ env.go-version }}
-    - run: make setup
-    - run: make test-bkop MYSQL_VERSION=${{ matrix.mysql-version }}
-    - run: make test-dbop MYSQL_VERSION=${{ matrix.mysql-version }}
+    uses: ./.github/workflows/dbtest.yaml
+    with:
+      mysql-version: ${{ matrix.mysql-version }}
+
   e2e:
     name: Supported Kubernetes versions End-to-End Tests
     strategy:
       matrix:
         mysql-version: ["8.0.30"]
         k8s-version: ["1.22.9", "1.23.6", "1.24.2"]
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version: ${{ env.go-version }}
-    - run: |
-        swapon > swapon.txt
-        sudo swapoff -a
-        cat swapon.txt | tail -n+2 | awk '$2=="file" {print $1}' | sudo xargs --no-run-if-empty rm
-    - run: sudo mkdir /mnt/local-path-provisioner0 /mnt/local-path-provisioner1 /mnt/local-path-provisioner2
-    - run: make start KUBERNETES_VERSION=${{ matrix.k8s-version }} MYSQL_VERSION=${{ matrix.mysql-version }} KIND_CONFIG=kind-config_actions.yaml
-      working-directory: e2e
-    - run: make test
-      working-directory: e2e
-    - run: make logs
-      working-directory: e2e
-      if: always()
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: logs-${{ matrix.k8s-version }}-${{ matrix.mysql-version }}.tar.gz
-        path: e2e/logs.tar.gz
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      k8s-version: ${{ matrix.k8s-version }}
+      mysql-version: ${{ matrix.mysql-version }}
+
   e2e-mysql:
     name: Supported MySQL versions End-to-End Tests
     strategy:
       matrix:
         mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30"]
         k8s-version: ["1.24.2"]
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.go-version }}
-      - run: |
-          swapon > swapon.txt
-          sudo swapoff -a
-          cat swapon.txt | tail -n+2 | awk '$2=="file" {print $1}' | sudo xargs --no-run-if-empty rm
-      - run: sudo mkdir /mnt/local-path-provisioner0 /mnt/local-path-provisioner1 /mnt/local-path-provisioner2
-      - run: make start KUBERNETES_VERSION=${{ matrix.k8s-version }} MYSQL_VERSION=${{ matrix.mysql-version }} KIND_CONFIG=kind-config_actions.yaml
-        working-directory: e2e
-      - run: make test
-        working-directory: e2e
-      - run: make logs
-        working-directory: e2e
-        if: always()
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: logs-${{ matrix.k8s-version }}-${{ matrix.mysql-version }}.tar.gz
-          path: e2e-mysql/logs.tar.gz
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      k8s-version: ${{ matrix.k8s-version }}
+      mysql-version: ${{ matrix.mysql-version }}
+
   upgrade:
     name: Upgrade Test
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,14 @@
 name: CI
+
 on:
   pull_request:
   push:
     branches:
-    - 'main'
+      - 'main'
+
 env:
-  go-version: 1.18
   cache-version: 1
+
 jobs:
   build:
     name: Build binaries
@@ -15,8 +17,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.go-version }}
+        go-version-file: go.mod
     - run: make release-build
+
   test:
     name: Small tests
     runs-on: ubuntu-20.04
@@ -24,64 +27,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.go-version }}
+        go-version-file: go.mod
     - run: make test
     - run: make check-generate
     - run: make envtest
-
-  dbtest:
-    name: Integration tests with MySQL
-    strategy:
-      matrix:
-        mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30"]
-    uses: ./.github/workflows/dbtest.yaml
-    with:
-      mysql-version: ${{ matrix.mysql-version }}
-
-  e2e:
-    name: Supported Kubernetes versions End-to-End Tests
-    strategy:
-      matrix:
-        mysql-version: ["8.0.30"]
-        k8s-version: ["1.22.9", "1.23.6", "1.24.2"]
-    uses: ./.github/workflows/e2e.yaml
-    with:
-      k8s-version: ${{ matrix.k8s-version }}
-      mysql-version: ${{ matrix.mysql-version }}
-
-  e2e-mysql:
-    name: Supported MySQL versions End-to-End Tests
-    strategy:
-      matrix:
-        mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30"]
-        k8s-version: ["1.24.2"]
-    uses: ./.github/workflows/e2e.yaml
-    with:
-      k8s-version: ${{ matrix.k8s-version }}
-      mysql-version: ${{ matrix.mysql-version }}
-
-  upgrade:
-    name: Upgrade Test
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version: ${{ env.go-version }}
-    - run: |
-        swapon > swapon.txt
-        sudo swapoff -a
-        cat swapon.txt | tail -n+2 | awk '$2=="file" {print $1}' | sudo xargs --no-run-if-empty rm
-    - run: sudo mkdir /mnt/local-path-provisioner0 /mnt/local-path-provisioner1 /mnt/local-path-provisioner2
-    - run: make start KIND_CONFIG=kind-config_actions.yaml
-      working-directory: e2e
-    - run: make test-upgrade
-      working-directory: e2e
-    - run: make logs
-      working-directory: e2e
-      if: always()
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: logs-upgrade.tar.gz
-        path: e2e/logs.tar.gz

--- a/.github/workflows/dbtest.yaml
+++ b/.github/workflows/dbtest.yaml
@@ -1,0 +1,20 @@
+name: Integration tests with MySQL
+
+on:
+  workflow_call:
+    inputs:
+      mysql-version:
+        required: true
+        type: string
+
+jobs:
+  dbtest:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - run: make setup
+      - run: make test-bkop MYSQL_VERSION=${{ inputs.mysql-version }}
+      - run: make test-dbop MYSQL_VERSION=${{ inputs.mysql-version }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,37 @@
+name: End-to-End Tests
+
+on:
+  workflow_call:
+    inputs:
+      mysql-version:
+        required: true
+        type: string
+      k8s-version:
+        required: true
+        type: string
+
+jobs:
+  e2e:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - run: |
+          swapon > swapon.txt
+          sudo swapoff -a
+          cat swapon.txt | tail -n+2 | awk '$2=="file" {print $1}' | sudo xargs --no-run-if-empty rm
+      - run: sudo mkdir /mnt/local-path-provisioner0 /mnt/local-path-provisioner1 /mnt/local-path-provisioner2
+      - run: make start KUBERNETES_VERSION=${{ inputs.k8s-version }} MYSQL_VERSION=${{ inputs.mysql-version }} KIND_CONFIG=kind-config_actions.yaml
+        working-directory: e2e
+      - run: make test
+        working-directory: e2e
+      - run: make logs
+        working-directory: e2e
+        if: always()
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: logs-${{ inputs.k8s-version }}-${{ inputs.mysql-version }}.tar.gz
+          path: e2e/logs.tar.gz

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -5,6 +5,8 @@ on:
     # 11:00 (JST)
     - cron: '0 2 * * 1'
   workflow_dispatch:
+  push:
+    branches:  ["bump-v*"]
 
 env:
   cache-version: 1

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     # 11:00 (JST)
     - cron: '0 2 * * 1'
+  workflow_dispatch:
 
 env:
   cache-version: 1

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,28 +1,20 @@
-name: E2E CI
+name: Weekly E2E
 
 on:
-  push:
-    branches: [main]
-    tags: ["v*"]
-    paths-ignore: ['**.md']
-  pull_request:
-    types: [opened, synchronize]
-    paths-ignore: ['**.md']
+  schedule:
+    # 11:00 (JST)
+    - cron: '0 2 * * 1'
 
 env:
   cache-version: 1
 
-# Use only the LTS version of MySQL for E2E running in CI.
-# Other MySQL supported versions tested weekly.
-# see: weekly.yaml
-#
-# NOTE: The LTS version is the version that Cybozu uses internally.
+# Weekly E2E tests using all MySQL versions supported by MOCO
 jobs:
   dbtest:
     name: Integration tests with MySQL
     strategy:
       matrix:
-        mysql-version: ["8.0.18", "8.0.28", "8.0.30"]
+        mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30"]
     uses: ./.github/workflows/dbtest.yaml
     with:
       mysql-version: ${{ matrix.mysql-version }}
@@ -42,7 +34,7 @@ jobs:
     name: Supported MySQL versions End-to-End Tests
     strategy:
       matrix:
-        mysql-version: ["8.0.18", "8.0.28", "8.0.30"]
+        mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30"]
         k8s-version: ["1.24.2"]
     uses: ./.github/workflows/e2e.yaml
     with:

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -26,9 +26,8 @@ To run these tests, use the following make targets respectively:
 3. `make envtest`
 4. Read [`e2e/README.md`](e2e/README.md)
 
-MOCO supports multiple MySQL versions,
-but the LTS version is defined as the MySQL version used within Cybozu.
-The three MySQL versions always used by CI are LTS, the latest, and one version before the latest.
+MOCO supports multiple MySQL versions.
+The three MySQL versions always used by CI are Cybozu internal use version, the latest, and one version before the latest.
 Other supported MySQL versions will be [tested only in Weekly](.github/workflows/weekly.yaml).
 
 ## Generated files

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -26,6 +26,11 @@ To run these tests, use the following make targets respectively:
 3. `make envtest`
 4. Read [`e2e/README.md`](e2e/README.md)
 
+MOCO supports multiple MySQL versions,
+but the LTS version is defined as the MySQL version used within Cybozu.
+The three MySQL versions always used by CI are LTS, the latest, and one version before the latest.
+Other supported MySQL versions will be [tested only in Weekly](.github/workflows/weekly.yaml).
+
 ## Generated files
 
 Some files in the repository are auto-generated.


### PR DESCRIPTION
There are many versions of MySQL supported by MOCO.

> MySQL: 8.0.18, 8.0.25, 8.0.26, 8.0.27, 8.0.28, 8.0.30

Since the matrix test will continue to grow if this is not done, the following policy is established.

* Determine the MySQL version of the LTS
  * This is the version that Cybozu uses internally
* In addition to the LTS version, CI will run the latest and one of the previous versions
* Matrix tests for all supported MySQL versions are run on a weekly basis