### PR TITLE
Add extraArgs to helm values.

### DIFF
--- a/charts/moco/README.md
+++ b/charts/moco/README.md
@@ -38,15 +38,16 @@ $ helm install --create-namespace --namespace moco-system moco -f values.yaml mo
 
 ## Values
 
-| Key                       | Type   | Default                                       | Description                                        |
-| ------------------------- | ------ | --------------------------------------------- | -------------------------------------------------- |
-| image.repository          | string | `"ghcr.io/cybozu-go/moco"`                    | MOCO image repository to use.                      |
-| image.tag                 | string | `{{ .Chart.AppVersion }}`                     | MOCO image tag to use.                             |
-| resources                 | object | `{"requests":{"cpu":"100m","memory":"20Mi"}}` | resources used by moco-controller.                 |
-| nodeSelector              | object | `{}`                                          | nodeSelector used by moco-controller.              |
-| affinity                  | object | `{}`                                          | affinity used by moco-controller.                  |
-| tolerations               | list   | `[]`                                          | tolerations used by moco-controller.               |
-| topologySpreadConstraints | list   | `[]`                                          | topologySpreadConstraints used by moco-controller. |
+| Key                       | Type   | Default                                       | Description                                                      |
+|---------------------------|--------|-----------------------------------------------|------------------------------------------------------------------|
+| image.repository          | string | `"ghcr.io/cybozu-go/moco"`                    | MOCO image repository to use.                                    |
+| image.tag                 | string | `{{ .Chart.AppVersion }}`                     | MOCO image tag to use.                                           |
+| resources                 | object | `{"requests":{"cpu":"100m","memory":"20Mi"}}` | resources used by moco-controller.                               |
+| extraArgs                 | list   | `[]`                                          | Additional command line flags to pass to moco-controller binary. |
+| nodeSelector              | object | `{}`                                          | nodeSelector used by moco-controller.                            |
+| affinity                  | object | `{}`                                          | affinity used by moco-controller.                                |
+| tolerations               | list   | `[]`                                          | tolerations used by moco-controller.                             |
+| topologySpreadConstraints | list   | `[]`                                          | topologySpreadConstraints used by moco-controller.               |
 
 ## Generate Manifests
 

--- a/charts/moco/templates/deployment.yaml
+++ b/charts/moco/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           name: moco-controller
+          {{- with .Values.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 9443
               name: webhook-server

--- a/charts/moco/values.yaml
+++ b/charts/moco/values.yaml
@@ -12,6 +12,9 @@ resources:
     cpu: 100m
     memory: 20Mi
 
+# extraArgs -- Additional command line flags to pass to moco-controller binary.
+extraArgs: []
+
 # nodeSelector -- nodeSelector used by moco-controller.
 nodeSelector: {}
 


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/462

Add an extraArgs field to the Helm chart that allows specifying moco-controller args.

values.yaml:

```yaml
extraArgs:
  - --agent-image=local/moco-agent:0.7.1
```

rendered:

```yaml
# Source: moco/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
<snip>
          name: moco-controller
          args:
            - --agent-image=local/moco-agent:0.7.1
          ports:
            - containerPort: 9443
              name: webhook-server
              protocol: TCP
            - containerPort: 8081
              name: health
              protocol: TCP
            - containerPort: 8080
              name: metrics
              protocol: TCP
<snip>
```
