### PR TITLE
Specify minimum Kubernetes version

### DIFF
--- a/charts/moco/Chart.yaml
+++ b/charts/moco/Chart.yaml
@@ -22,3 +22,5 @@ version: 0.3.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: 0.13.0
+
+kubeVersion: ">= 1.22.0"


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/463

Current Helm chart does not work with Kubernetes v1.21 or lower by default.
Specify the minimum Kubernetes version.

e.g.

```console
$ helm install moco ./charts/moco/
Error: INSTALLATION FAILED: chart requires kubeVersion: >= 1.22.0 which is incompatible with Kubernetes v1.21.12
```