### PR TITLE
Introduce completion

### DIFF
--- a/cmd/kubectl-moco/cmd/completion.go
+++ b/cmd/kubectl-moco/cmd/completion.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+
+	mocov1beta2 "github.com/cybozu-go/moco/api/v1beta2"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func mysqlClusterCandidates(ctx context.Context, cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var namespace string
+
+	if cmd.Flags().Changed("namespace") {
+		ns, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		namespace = ns
+	} else {
+		ns, _, err := kubeConfigFlags.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		namespace = ns
+	}
+
+	clusters := &mocov1beta2.MySQLClusterList{}
+	if err := kubeClient.List(ctx, clusters, &client.ListOptions{
+		Namespace: namespace,
+	}); err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var candidates []string
+	for _, c := range clusters.Items {
+		if !strings.HasPrefix(c.Name, toComplete) {
+			continue
+		}
+		candidates = append(candidates, c.Name)
+	}
+
+	return candidates, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/kubectl-moco/cmd/credential.go
+++ b/cmd/kubectl-moco/cmd/credential.go
@@ -50,6 +50,9 @@ func init() {
 	fs.StringVarP(&credentialConfig.user, "mysql-user", "u", "moco-readonly", "User for login to mysql")
 	fs.StringVar(&credentialConfig.format, "format", "plain", "The format of output [`plain` or `mycnf`]")
 
+	_ = credentialCmd.RegisterFlagCompletionFunc("mysql-user", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"moco-readonly", "moco-writable", "moco-admin"}, cobra.ShellCompDirectiveDefault
+	})
 	_ = credentialCmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"plain", "mycnf"}, cobra.ShellCompDirectiveDefault
 	})

--- a/cmd/kubectl-moco/cmd/credential.go
+++ b/cmd/kubectl-moco/cmd/credential.go
@@ -22,8 +22,7 @@ var credentialCmd = &cobra.Command{
 		return fetchCredential(cmd.Context(), args[0])
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		ctx := context.Background()
-		return mysqlClusterCandidates(ctx, cmd, args, toComplete)
+		return mysqlClusterCandidates(cmd.Context(), cmd, args, toComplete)
 	},
 }
 

--- a/cmd/kubectl-moco/cmd/credential.go
+++ b/cmd/kubectl-moco/cmd/credential.go
@@ -21,6 +21,10 @@ var credentialCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return fetchCredential(cmd.Context(), args[0])
 	},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := context.Background()
+		return mysqlClusterCandidates(ctx, cmd, args, toComplete)
+	},
 }
 
 func fetchCredential(ctx context.Context, clusterName string) error {
@@ -46,6 +50,10 @@ func init() {
 	fs := credentialCmd.Flags()
 	fs.StringVarP(&credentialConfig.user, "mysql-user", "u", "moco-readonly", "User for login to mysql")
 	fs.StringVar(&credentialConfig.format, "format", "plain", "The format of output [`plain` or `mycnf`]")
+
+	_ = credentialCmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"plain", "mycnf"}, cobra.ShellCompDirectiveDefault
+	})
 
 	rootCmd.AddCommand(credentialCmd)
 }

--- a/cmd/kubectl-moco/cmd/mysql.go
+++ b/cmd/kubectl-moco/cmd/mysql.go
@@ -37,8 +37,7 @@ var mysqlCmd = &cobra.Command{
 		return runMySQLCommand(cmd.Context(), args[0], cmd, args[1:])
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		ctx := context.Background()
-		return mysqlClusterCandidates(ctx, cmd, args, toComplete)
+		return mysqlClusterCandidates(cmd.Context(), cmd, args, toComplete)
 	},
 }
 

--- a/cmd/kubectl-moco/cmd/mysql.go
+++ b/cmd/kubectl-moco/cmd/mysql.go
@@ -36,6 +36,10 @@ var mysqlCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runMySQLCommand(cmd.Context(), args[0], cmd, args[1:])
 	},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := context.Background()
+		return mysqlClusterCandidates(ctx, cmd, args, toComplete)
+	},
 }
 
 func runMySQLCommand(ctx context.Context, clusterName string, cmd *cobra.Command, args []string) error {

--- a/cmd/kubectl-moco/cmd/switchover.go
+++ b/cmd/kubectl-moco/cmd/switchover.go
@@ -19,6 +19,10 @@ var switchoverCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return switchover(cmd.Context(), args[0])
 	},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := context.Background()
+		return mysqlClusterCandidates(ctx, cmd, args, toComplete)
+	},
 }
 
 func switchover(ctx context.Context, name string) error {

--- a/cmd/kubectl-moco/cmd/switchover.go
+++ b/cmd/kubectl-moco/cmd/switchover.go
@@ -20,8 +20,7 @@ var switchoverCmd = &cobra.Command{
 		return switchover(cmd.Context(), args[0])
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		ctx := context.Background()
-		return mysqlClusterCandidates(ctx, cmd, args, toComplete)
+		return mysqlClusterCandidates(cmd.Context(), cmd, args, toComplete)
 	},
 }
 


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/354

> 📝 
>
> Completion is currently not available via kubectl plugin.
>
> ref: https://github.com/kubernetes/kubernetes/pull/105867

Introduce completion for kubectl-moco.
The `completion` subcommand is now available by default in cobra.

```console
$ kubectl-moco -h
the utility command for MOCO.

Usage:
  kubectl-moco [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
<snip>
```

Subcommand completion is currently available.

```console
$ kubectl-moco [tab]
-- completions --
completion  -- Generate the autocompletion script for the specified shell
credential  -- Fetch the credential of a specified user
help        -- Help about any command
mysql       -- Run mysql command in a specified MySQL instance
switchover  -- Switch the primary instance
```

This PR enables cluster name completion and flag completion.

e.g.

```console
$ kubectl-moco mysql -n foo [tab]
-- completions --
test

$ kubectl-moco credential --format [tab]
-- completions --
mycnf  plain
```
