### PR TITLE
Completion mysql-user option in kubectl-moco mysql

### DIFF
--- a/cmd/kubectl-moco/cmd/credential.go
+++ b/cmd/kubectl-moco/cmd/credential.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cybozu-go/moco/pkg/constants"
 	"github.com/spf13/cobra"
 )
 
@@ -47,11 +48,11 @@ password="%s"
 
 func init() {
 	fs := credentialCmd.Flags()
-	fs.StringVarP(&credentialConfig.user, "mysql-user", "u", "moco-readonly", "User for login to mysql")
+	fs.StringVarP(&credentialConfig.user, "mysql-user", "u", constants.ReadOnlyUser, "User for login to mysql")
 	fs.StringVar(&credentialConfig.format, "format", "plain", "The format of output [`plain` or `mycnf`]")
 
 	_ = credentialCmd.RegisterFlagCompletionFunc("mysql-user", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"moco-readonly", "moco-writable", "moco-admin"}, cobra.ShellCompDirectiveDefault
+		return []string{constants.ReadOnlyUser, constants.WritableUser, constants.AdminUser}, cobra.ShellCompDirectiveDefault
 	})
 	_ = credentialCmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"plain", "mycnf"}, cobra.ShellCompDirectiveDefault

--- a/cmd/kubectl-moco/cmd/mysql.go
+++ b/cmd/kubectl-moco/cmd/mysql.go
@@ -86,10 +86,14 @@ func runMySQLCommand(ctx context.Context, clusterName string, cmd *cobra.Command
 
 func init() {
 	fs := mysqlCmd.Flags()
-	fs.StringVarP(&mysqlConfig.user, "mysql-user", "u", "moco-readonly", "User for login to mysql")
+	fs.StringVarP(&mysqlConfig.user, "mysql-user", "u", constants.ReadOnlyUser, "User for login to mysql")
 	fs.IntVar(&mysqlConfig.index, "index", -1, "Index of the target mysql instance")
 	fs.BoolVarP(&mysqlConfig.stdin, "stdin", "i", false, "Pass stdin to the mysql container")
 	fs.BoolVarP(&mysqlConfig.tty, "tty", "t", false, "Allocate a TTY to stdin")
+
+	_ = mysqlCmd.RegisterFlagCompletionFunc("mysql-user", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{constants.ReadOnlyUser, constants.WritableUser, constants.AdminUser}, cobra.ShellCompDirectiveDefault
+	})
 
 	rootCmd.AddCommand(mysqlCmd)
 }


### PR DESCRIPTION
ref: https://github.com/cybozu-go/moco/issues/354, https://github.com/cybozu-go/moco/pull/470

Add a completion for `--mysql-user`(`-u`) option of `kubectl-moco mysql`.

```bash
$ . <(kubectl-moco completion bash)
$ kubectl-moco mysql -u moco- [tab]
-- completions --
moco-admin     moco-readonly  moco-writable
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>