### PR TITLE
Use ExecutedGtidSet and RetrievedGtidSet when determining the primary

### DIFF
--- a/e2e/failover_test.go
+++ b/e2e/failover_test.go
@@ -70,10 +70,20 @@ var _ = Context("failure", func() {
 			if err != nil {
 				return err
 			}
-			if currentPrimaryIndex != cluster.Status.CurrentPrimaryIndex {
-				return nil
+			if currentPrimaryIndex == cluster.Status.CurrentPrimaryIndex {
+				return errors.New("failover not yet executed")
 			}
-			return errors.New("failover not yet executed")
+
+			for _, cond := range cluster.Status.Conditions {
+				if cond.Type != mocov1beta2.ConditionHealthy {
+					continue
+				}
+				if cond.Status == corev1.ConditionTrue {
+					return nil
+				}
+				return fmt.Errorf("cluster is not healthy: %s", cond.Status)
+			}
+			return errors.New("no health condition")
 		}).Should(Succeed())
 
 		// Immediately after replication,
@@ -106,10 +116,20 @@ var _ = Context("failure", func() {
 			if err != nil {
 				return err
 			}
-			if currentPrimaryIndex != cluster.Status.CurrentPrimaryIndex {
-				return nil
+			if currentPrimaryIndex == cluster.Status.CurrentPrimaryIndex {
+				return errors.New("failover not yet executed")
 			}
-			return errors.New("failover not yet executed")
+
+			for _, cond := range cluster.Status.Conditions {
+				if cond.Type != mocov1beta2.ConditionHealthy {
+					continue
+				}
+				if cond.Status == corev1.ConditionTrue {
+					return nil
+				}
+				return fmt.Errorf("cluster is not healthy: %s", cond.Status)
+			}
+			return errors.New("no health condition")
 		}).Should(Succeed())
 	})
 

--- a/e2e/failover_test.go
+++ b/e2e/failover_test.go
@@ -1,0 +1,119 @@
+package e2e
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+
+	mocov1beta2 "github.com/cybozu-go/moco/api/v1beta2"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+//go:embed testdata/failover.yaml
+var failoverYAML string
+
+var _ = Context("failure", func() {
+	if doUpgrade {
+		return
+	}
+
+	It("should construct a 3-instance cluster", func() {
+		kubectlSafe(fillTemplate(failoverYAML), "apply", "-f", "-")
+		Eventually(func() error {
+			cluster, err := getCluster("failover", "test")
+			if err != nil {
+				return err
+			}
+			for _, cond := range cluster.Status.Conditions {
+				if cond.Type != mocov1beta2.ConditionHealthy {
+					continue
+				}
+				if cond.Status == corev1.ConditionTrue {
+					return nil
+				}
+				return fmt.Errorf("cluster is not healthy: %s", cond.Status)
+			}
+			return errors.New("no health condition")
+		}).Should(Succeed())
+
+		kubectlSafe(nil, "moco", "mysql", "test",
+			"-n", "failover",
+			"-u", "moco-writable",
+			"--", "-e", "CREATE DATABASE test;")
+		kubectlSafe(nil, "moco", "mysql", "test",
+			"-n", "failover",
+			"-u", "moco-writable",
+			"--", "-e", "CREATE TABLE test.t1 (foo int);")
+		kubectlSafe(nil, "moco", "mysql", "test",
+			"-n", "failover",
+			"-u", "moco-writable",
+			"--", "-e", "INSERT INTO test.t1 (foo) VALUES (1); COMMIT;")
+	})
+
+	It("should successful failover ", func() {
+		By("kill primary instance")
+		cluster, err := getCluster("failover", "test")
+		Expect(err).NotTo(HaveOccurred())
+
+		currentPrimaryIndex := cluster.Status.CurrentPrimaryIndex
+		kubectlSafe(nil, "exec",
+			fmt.Sprintf("moco-test-%d", currentPrimaryIndex),
+			"-n", "failover",
+			"-c", "mysqld",
+			"--", "kill", "1")
+
+		By("switch primary instance")
+		Eventually(func() error {
+			cluster, err := getCluster("failover", "test")
+			if err != nil {
+				return err
+			}
+			if currentPrimaryIndex != cluster.Status.CurrentPrimaryIndex {
+				return nil
+			}
+			return errors.New("failover not yet executed")
+		}).Should(Succeed())
+
+		// Immediately after replication,
+		// 'Retrieved_Gtid_Set' will be empty if there are no new transactions.
+		//
+		//
+		// SHOW REPLICA STATUS\G
+		//*************************** 1. row ***************************
+		//...
+		//           Retrieved_Gtid_Set: <empty>
+		//            Executed_Gtid_Set: 09a2bf6a-960c-11ec-bf89-9ee9543e8238:1,
+		//09c0848a-960c-11ec-90e9-0a55db88221e:1-4
+		//...
+		//
+		// Verify that failover succeeds even if 'Retrieved_Gtid_Set' is empty.
+		// https://github.com/cybozu-go/moco/issues/370
+		By("kill primary instance one more")
+		cluster, err = getCluster("failover", "test")
+		Expect(err).NotTo(HaveOccurred())
+
+		kubectlSafe(nil, "exec",
+			fmt.Sprintf("moco-test-%d", cluster.Status.CurrentPrimaryIndex),
+			"-n", "failover",
+			"-c", "mysqld",
+			"--", "kill", "1")
+
+		By("switch primary instance")
+		Eventually(func() error {
+			cluster, err := getCluster("failover", "test")
+			if err != nil {
+				return err
+			}
+			if currentPrimaryIndex != cluster.Status.CurrentPrimaryIndex {
+				return nil
+			}
+			return errors.New("failover not yet executed")
+		}).Should(Succeed())
+	})
+
+	It("should delete clusters", func() {
+		kubectlSafe(nil, "delete", "-n", "failover", "mysqlclusters", "--all")
+	})
+})

--- a/e2e/failover_test.go
+++ b/e2e/failover_test.go
@@ -79,6 +79,7 @@ var _ = Context("failure", func() {
 					continue
 				}
 				if cond.Status == corev1.ConditionTrue {
+					currentPrimaryIndex = cluster.Status.CurrentPrimaryIndex
 					return nil
 				}
 				return fmt.Errorf("cluster is not healthy: %s", cond.Status)

--- a/e2e/testdata/failover.yaml
+++ b/e2e/testdata/failover.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: failover
+---
+apiVersion: moco.cybozu.com/v1beta2
+kind: MySQLCluster
+metadata:
+  namespace: failover
+  name: test
+spec:
+  replicas: 3
+  podTemplate:
+    spec:
+      containers:
+        - name: mysqld
+          image: quay.io/cybozu/mysql:{{ . }}
+    # Specify minimum resources so as not to overwhelm CI resources.
+    overwriteContainers:
+      - name: agent
+        resources:
+          requests:
+            cpu: 1m
+      - name: moco-init
+        resources:
+          requests:
+            cpu: 1m
+      - name: slow-log
+        resources:
+          requests:
+            cpu: 1m
+      - name: mysqld-exporter
+        resources:
+          requests:
+            cpu: 1m
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/370

Use Executed_Gtid_Set and Retrieved_Gtid_Set when determining the primary.

Previously, only Retrieved_Gtid_Set was used to select the primary.
However, there are cases where Retrieved_Gtid_Set is empty immediately after replication starts if there are no new transactions.

```console
$ kubectl-moco mysql test --index 2 -- -e "SHOW REPLICA STATUS\G"
*************************** 1. row ***************************
             Replica_IO_State: Waiting for source to send event
...
           Retrieved_Gtid_Set:
            Executed_Gtid_Set: 09a2bf6a-960c-11ec-bf89-9ee9543e8238:1,
09c0848a-960c-11ec-90e9-0a55db88221e:1-4
...
```

Therefore, change to also use ExecutedGtidSet for finding primary.

```go
// There are cases where Retrieved_Gtid_Set is empty,
// such as when there is no transaction immediately after a fail-over.
// Therefore, Retrieved_Gtid_Set and Executed_Gtid_Set are unioned to find for the top runner.
// The union of two GTID sets is simply their joined together with an interposed comma.
// https://dev.mysql.com/doc/refman/8.0/en/gtid-functions.html
var gtids string
if len(repl.RetrievedGtidSet) == 0 {
	gtids = repl.ExecutedGtidSet
} else {
	gtids = fmt.Sprintf("%s,%s", repl.RetrievedGtidSet, repl.ExecutedGtidSet)
}
```


### Steps

1. Submitting data

```console
$ kubectl-moco mysql test -it -u moco-writable -- -e "CREATE DATABASE test;"
$ kubectl-moco mysql test -it -u moco-writable -- -e "CREATE TABLE test.t1 (foo int);"
$ kubectl-moco mysql test -it -u moco-writable -- -e "INSERT INTO test.t1 (foo) VALUES (1); COMMIT;"
```

2. Kills the primary and causes failover

```console
$ kubectl get mysqlcluster test
$ PRIMARY=$(kubectl get mysqlcluster test -o jsonpath='{.status.currentPrimaryIndex}')
$ kubectl exec -it moco-test-${PRIMARY} -c mysqld -- kill 1
```

3. Kill the primary again

```console
$ PRIMARY=$(kubectl get mysqlcluster test -o jsonpath='{.status.currentPrimaryIndex}')
$ kubectl exec -it moco-test-${PRIMARY} -c mysqld -- kill 1
```

4. The following log is output and failover fails

```
{"level":"error","ts":1646976101.8021455,"logger":"cluster-manager.default/test","msg":"error","error":"failed to failover: failed to choose the next primary: unable to determine the top runner"}
```
