### PR TITLE
Fix INSTALL PLUGIN command in the usage document

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -133,7 +133,7 @@ After the cloning, MOCO needs to create some user accounts and install plugins.
 **On the donor**, you need to install the plugin and create two user accounts as follows:
 
 ```console
-mysql> INSTALL PLUGIN clone SONAME mysql_clone.so;
+mysql> INSTALL PLUGIN clone SONAME 'mysql_clone.so';
 mysql> CREATE USER 'clone-donor'@'%' IDENTIFIED BY 'xxxxxxxxxxx';
 mysql> GRANT BACKUP_ADMIN, REPLICATION SLAVE ON *.* TO 'clone-donor'@'%';
 mysql> CREATE USER 'clone-init'@'localhost' IDENTIFIED BY 'yyyyyyyyyyy';


### PR DESCRIPTION
I tried to setup a MySQL cluster following the instruction below, but `INSTALL PLUGIN` command failed.
https://cybozu-go.github.io/moco/usage.html#creating-a-cluster-that-replicates-data-from-an-external-mysqld

```
mysql> INSTALL PLUGIN clone SONAME mysql_clone.so;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'mysql_clone.so' at line 1
```

It seems that `INSTALL PLUGIN clone SONAME 'mysql_clone.so';` is correct according to the official document.
https://dev.mysql.com/doc/refman/8.0/en/clone-plugin-installation.html