### PR TITLE
Relax the kubeVersion constraints in Chart.yaml

### DIFF
--- a/charts/moco/CHANGELOG.md
+++ b/charts/moco/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Relax the kubeVersion constraints in Chart.yaml [#487](https://github.com/cybozu-go/moco/pull/487)
+
 ## [0.4.0] - 2022-11-29
 
 ### Added

--- a/charts/moco/Chart.yaml
+++ b/charts/moco/Chart.yaml
@@ -23,4 +23,7 @@ version: 0.4.0
 # It is recommended to use it with quotes.
 appVersion: 0.14.0
 
-kubeVersion: ">= 1.23.0"
+# This version does not necessarily match the supported version. This version number
+# will be updated when there is an obviously uninstallable version. If there are no
+# problems, update only moco/README.md#supported-software for the corresponding kubernetes version.
+kubeVersion: ">= 1.22.0"


### PR DESCRIPTION
#483 
Relax the `kubeVersion` constraints in Chart.yaml. The `kubeVersion` will be updated when there is an obviously uninstallable version. 
Signed-off-by: kouki <kouworld0123@gmail.com>