### PR TITLE
Ignore primary's event when detecting errant replicas

### DIFF
--- a/clustering/manager_test.go
+++ b/clustering/manager_test.go
@@ -676,7 +676,7 @@ var _ = Describe("manager", func() {
 		testSetGTID(cluster.PodHostname(1), "p0:1,p0:2,p1:1") // errant replica
 		testSetGTID(cluster.PodHostname(2), "p0:1")
 		testSetGTID(cluster.PodHostname(3), "p0:1,p0:2,p0:3")
-		testSetGTID(cluster.PodHostname(4), "p0:1,p0:2,p0:3,p0:4")
+		testSetGTID(cluster.PodHostname(4), "p0:1,p0:2,p0:3,p0:4,p0:5")
 		Eventually(func() int {
 			cluster, err = testGetCluster(ctx)
 			if err != nil {
@@ -719,8 +719,8 @@ var _ = Describe("manager", func() {
 
 		By("triggering a failover")
 		of.setRetrievedGTIDSet(cluster.PodHostname(2), "p0:1")
-		of.setRetrievedGTIDSet(cluster.PodHostname(3), "p0:1,p0:2,p0:3,p0:4")
-		of.setRetrievedGTIDSet(cluster.PodHostname(4), "p0:1,p0:2,p0:3,p0:4")
+		of.setRetrievedGTIDSet(cluster.PodHostname(3), "p0:1,p0:2,p0:3,p0:4,p0:5")
+		of.setRetrievedGTIDSet(cluster.PodHostname(4), "p0:1,p0:2,p0:3,p0:4,p0:5")
 		of.setFailing(cluster.PodHostname(0), true)
 
 		Eventually(func() int {
@@ -733,7 +733,7 @@ var _ = Describe("manager", func() {
 
 		// confirm that MOCO waited fot the retrieved GTID set to be executed
 		st3 := of.getInstanceStatus(cluster.PodHostname(3))
-		Expect(st3.GlobalVariables.ExecutedGTID).To(Equal("p0:1,p0:2,p0:3,p0:4"))
+		Expect(st3.GlobalVariables.ExecutedGTID).To(Equal("p0:1,p0:2,p0:3,p0:4,p0:5"))
 
 		Eventually(func() bool {
 			cluster, err = testGetCluster(ctx)

--- a/clustering/status.go
+++ b/clustering/status.go
@@ -261,7 +261,7 @@ func (p *managerProcess) GatherStatus(ctx context.Context) (*StatusSet, error) {
 }
 
 // containErrantTransactions check whether a GTID set contains errant transactions.
-// When the primary load is high, in the rare case, gtid_executed of replicas precedes the primary. (Probably only one event)
+// When the primary load is high, in the rare case, gtid_executed of replicas precedes the primary.
 // Assuming such a situation, this function ignores primary's event.
 func containErrantTransactions(primaryUUID, gtidSet string) bool {
 	if primaryUUID == "" {
@@ -286,17 +286,13 @@ func containErrantTransactions(primaryUUID, gtidSet string) bool {
 	//   (n >= 1)
 	// ref: https: //dev.mysql.com/doc/refman/8.0/en/replication-gtids-concepts.html
 
-	uuidSets := strings.Split(gtidSet, ",")
-	if len(uuidSets) > 1 {
-		return true
+	for _, uuidSet := range strings.Split(gtidSet, ",") {
+		split := strings.SplitN(uuidSet, ":", 2)
+		if split[0] != primaryUUID {
+			return true
+		}
 	}
-	split := strings.Split(uuidSets[0], ":")
-	if split[0] != primaryUUID {
-		return true
-	}
-	// If two or more events exist, they are considered errant transactions.
-	intervals := split[1:]
-	return len(intervals) > 1 || strings.Contains(intervals[0], "-")
+	return false
 }
 
 func isPodReady(pod *corev1.Pod) bool {

--- a/clustering/status.go
+++ b/clustering/status.go
@@ -225,7 +225,9 @@ func (p *managerProcess) GatherStatus(ctx context.Context) (*StatusSet, error) {
 		ss.ExecutedGTID = pst.GlobalVariables.ExecutedGTID
 	}
 
+	// detect errant replicas
 	if ss.ExecutedGTID != "" {
+		pst := ss.MySQLStatus[ss.Primary]
 		for i, ist := range ss.MySQLStatus {
 			if i == ss.Primary {
 				continue
@@ -234,11 +236,11 @@ func (p *managerProcess) GatherStatus(ctx context.Context) (*StatusSet, error) {
 				continue
 			}
 
-			ok, err := ss.DBOps[ss.Primary].IsSubsetGTID(ctx, ist.GlobalVariables.ExecutedGTID, ss.ExecutedGTID)
+			diff, err := ss.DBOps[ss.Primary].SubtractGTID(ctx, ist.GlobalVariables.ExecutedGTID, ss.ExecutedGTID)
 			if err != nil {
-				return nil, fmt.Errorf("failed to compare GTID %s and %s: %w", ist.GlobalVariables.ExecutedGTID, ss.ExecutedGTID, err)
+				return nil, fmt.Errorf("failed to compare GTID for instance %d: %w", i, err)
 			}
-			if !ok {
+			if containErrantTransactions(pst.GlobalVariables.UUID, diff) {
 				ist.IsErrant = true
 				ss.Errants = append(ss.Errants, i)
 			}
@@ -256,6 +258,45 @@ func (p *managerProcess) GatherStatus(ctx context.Context) (*StatusSet, error) {
 
 	ss.DecideState()
 	return ss, nil
+}
+
+// containErrantTransactions check whether a GTID set contains errant transactions.
+// When the primary load is high, in the rare case, gtid_executed of replicas precedes the primary. (Probably only one event)
+// Assuming such a situation, this function ignores primary's event.
+func containErrantTransactions(primaryUUID, gtidSet string) bool {
+	if primaryUUID == "" {
+		panic("uuid must be set")
+	}
+	if gtidSet == "" {
+		return false
+	}
+
+	// Syntax of GTID set
+	//   gtid_set:
+	//       uuid_set [, uuid_set] ...
+	//       | ''
+	//   uuid_set:
+	//       uuid:interval[:interval]...
+	//   uuid:
+	//       hhhhhhhh-hhhh-hhhh-hhhh-hhhhhhhhhhhh
+	//   h:
+	//       [0-9|A-F]
+	//   interval:
+	//       n[-n]
+	//   (n >= 1)
+	// ref: https: //dev.mysql.com/doc/refman/8.0/en/replication-gtids-concepts.html
+
+	uuidSets := strings.Split(gtidSet, ",")
+	if len(uuidSets) > 1 {
+		return true
+	}
+	split := strings.Split(uuidSets[0], ":")
+	if split[0] != primaryUUID {
+		return true
+	}
+	// If two or more events exist, they are considered errant transactions.
+	intervals := split[1:]
+	return len(intervals) > 1 || strings.Contains(intervals[0], "-")
 }
 
 func isPodReady(pod *corev1.Pod) bool {

--- a/pkg/dbop/gtid.go
+++ b/pkg/dbop/gtid.go
@@ -64,3 +64,11 @@ func (o *operator) IsSubsetGTID(ctx context.Context, set1, set2 string) (bool, e
 	}
 	return ret, nil
 }
+
+func (o *operator) SubtractGTID(ctx context.Context, set1, set2 string) (string, error) {
+	var ret string
+	if err := o.db.GetContext(ctx, &ret, `SELECT GTID_SUBTRACT(?,?)`, set1, set2); err != nil {
+		return "", fmt.Errorf("failed to get gtid_subtract(%s, %s): %w", set1, set2, err)
+	}
+	return ret, nil
+}

--- a/pkg/dbop/nop.go
+++ b/pkg/dbop/nop.go
@@ -27,6 +27,10 @@ func (o NopOperator) GetStatus(context.Context) (*MySQLInstanceStatus, error) {
 	return nil, ErrNop
 }
 
+func (o NopOperator) SubtractGTID(ctx context.Context, set1, set2 string) (string, error) {
+	return "", ErrNop
+}
+
 func (o NopOperator) IsSubsetGTID(ctx context.Context, set1, set2 string) (bool, error) {
 	return false, ErrNop
 }

--- a/pkg/dbop/operator.go
+++ b/pkg/dbop/operator.go
@@ -31,6 +31,9 @@ type Operator interface {
 	// GetStatus reports the instance status.
 	GetStatus(context.Context) (*MySQLInstanceStatus, error)
 
+	// SubtractGTID returns GTID subset of set1 that are not in set2.
+	SubtractGTID(ctx context.Context, set1, set2 string) (string, error)
+
 	// IsSubsetGTID returns true if set1 is a subset of set2.
 	IsSubsetGTID(ctx context.Context, set1, set2 string) (bool, error)
 

--- a/pkg/dbop/types.go
+++ b/pkg/dbop/types.go
@@ -21,6 +21,7 @@ type MySQLInstanceStatus struct {
 }
 
 var statusGlobalVars = []string{
+	"@@server_uuid",
 	"@@gtid_executed",
 	"@@read_only",
 	"@@super_read_only",
@@ -31,6 +32,7 @@ var statusGlobalVars = []string{
 
 // GlobalVariables defines the observed global variable values of a MySQL instance
 type GlobalVariables struct {
+	UUID                  string `db:"@@server_uuid"`
 	ExecutedGTID          string `db:"@@gtid_executed"`
 	ReadOnly              bool   `db:"@@read_only"`
 	SuperReadOnly         bool   `db:"@@super_read_only"`


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/419

When the primary MySQL load is high, in the rare case, it will delay the execution of transactions in the primary, and the `gtid_executed` of replicas precedes the primary.
In this case, the moco-controller recognizes preceding replicas as errant replicas and purges them from a MySQLCluster.
We have faced this situation twice, and in both cases, the moco-controller purged all replicas, and the MySQLCluster became unavailable.

This PR fixes the detection logic for errant transactions to prevent cluster collapse as described above.
We allow replicas to precede the primary only one event.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>