### PR TITLE
Add metrics to measure processing time

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -16,21 +16,22 @@ Aside from [the standard Go runtime and process metrics][standard], it exposes m
 
 All these metrics are prefixed with `moco_cluster_` and have `name` and `namespace` labels.
 
-| Name                                | Description                                                            | Type    |
-|-------------------------------------|------------------------------------------------------------------------|---------|
-| `checks_total`                      | The number of times MOCO checked the cluster                           | Counter |
-| `errors_total`                      | The number of times MOCO encountered errors when managing the cluster  | Counter |
-| `available`                         | 1 if the cluster is available, 0 otherwise                             | Gauge   |
-| `healthy`                           | 1 if the cluster is running without any problems, 0 otherwise          | Gauge   |
-| `switchover_total`                  | The number of times MOCO changed the live primary instance             | Counter |
-| `failover_total`                    | The number of times MOCO changed the failed primary instance           | Counter |
-| `replicas`                          | The number of mysqld instances in the cluster                          | Gauge   |
-| `ready_replicas`                    | The number of ready mysqld Pods in the cluster                         | Gauge   |
-| `errant_replicas`                   | The number of mysqld instances that have [errant transactions][errant] | Gauge   |
-| `volume_resized_total`              | The number of successful volume resizes                                | Counter |
-| `volume_resized_errors_total`       | The number of failed volume resizes                                    | Counter |
-| `statefulset_recreate_total`        | The number of successful StatefulSet recreates                         | Counter |
-| `statefulset_recreate_errors_total` | The number of failed StatefulSet recreates                             | Counter |
+| Name                                | Description                                                            | Type      |
+| ----------------------------------- | ---------------------------------------------------------------------- | --------- |
+| `checks_total`                      | The number of times MOCO checked the cluster                           | Counter   |
+| `errors_total`                      | The number of times MOCO encountered errors when managing the cluster  | Counter   |
+| `available`                         | 1 if the cluster is available, 0 otherwise                             | Gauge     |
+| `healthy`                           | 1 if the cluster is running without any problems, 0 otherwise          | Gauge     |
+| `switchover_total`                  | The number of times MOCO changed the live primary instance             | Counter   |
+| `failover_total`                    | The number of times MOCO changed the failed primary instance           | Counter   |
+| `replicas`                          | The number of mysqld instances in the cluster                          | Gauge     |
+| `ready_replicas`                    | The number of ready mysqld Pods in the cluster                         | Gauge     |
+| `errant_replicas`                   | The number of mysqld instances that have [errant transactions][errant] | Gauge     |
+| `processing_time_seconds`           | The length of time in seconds processing the cluster                   | Histogram |
+| `volume_resized_total`              | The number of successful volume resizes                                | Counter   |
+| `volume_resized_errors_total`       | The number of failed volume resizes                                    | Counter   |
+| `statefulset_recreate_total`        | The number of successful StatefulSet recreates                         | Counter   |
+| `statefulset_recreate_errors_total` | The number of failed StatefulSet recreates                             | Counter   |
 
 ### Backup
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,6 +21,7 @@ var (
 	TotalReplicasVec   *prometheus.GaugeVec
 	ReadyReplicasVec   *prometheus.GaugeVec
 	ErrantReplicasVec  *prometheus.GaugeVec
+	ProcessingTimeVec  *prometheus.HistogramVec
 
 	VolumeResizedTotal            *prometheus.CounterVec
 	VolumeResizedErrorTotal       *prometheus.CounterVec
@@ -111,6 +112,15 @@ func Register(registry prometheus.Registerer) {
 		Help:      "The number of instances that have errant transactions",
 	}, []string{"name", "namespace"})
 	registry.MustRegister(ErrantReplicasVec)
+
+	ProcessingTimeVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: clusteringSubsystem,
+		Name:      "processing_time_seconds",
+		Help:      "The length of time in seconds processing the cluster",
+		Buckets:   []float64{0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10, 20, 30},
+	}, []string{"name", "namespace"})
+	registry.MustRegister(ProcessingTimeVec)
 
 	BackupTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metricsNamespace,


### PR DESCRIPTION
Add metrics to measure the processing time of cluster-manager goroutines.
It may be helpful with performance tuning.

| Name                                | Type    |
|-------------------------------------|--------|
| `moco_cluster_processing_time_seconds` | histogram |

With this change, the moco-controller will expose the following metrics.

```
$ curl -sS localhost:8080/metrics | grep processing_time
# HELP moco_cluster_processing_time_seconds The length of time in seconds processing the cluster
# TYPE moco_cluster_processing_time_seconds histogram
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="0.1"} 7
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="0.25"} 19
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="0.5"} 19
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="0.75"} 19
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="1"} 19
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="2.5"} 19
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="5"} 19
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="7.5"} 19
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="10"} 23
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="20"} 23
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="30"} 23
moco_cluster_processing_time_seconds_bucket{name="cluster1",namespace="foo",le="+Inf"} 23
moco_cluster_processing_time_seconds_sum{name="cluster1",namespace="foo"} 38.11477838000001
moco_cluster_processing_time_seconds_count{name="cluster1",namespace="foo"} 23
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="0.1"} 11
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="0.25"} 65
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="0.5"} 65
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="0.75"} 66
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="1"} 66
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="2.5"} 66
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="5"} 66
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="7.5"} 66
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="10"} 73
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="20"} 73
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="30"} 73
moco_cluster_processing_time_seconds_bucket{name="cluster2",namespace="bar",le="+Inf"} 73
moco_cluster_processing_time_seconds_sum{name="cluster2",namespace="bar"} 70.92830542099993
moco_cluster_processing_time_seconds_count{name="cluster2",namespace="bar"} 73
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>