### PR TITLE
Add pprof server to moco-controller

### DIFF
--- a/cmd/moco-controller/cmd/root.go
+++ b/cmd/moco-controller/cmd/root.go
@@ -25,6 +25,7 @@ var (
 var config struct {
 	metricsAddr             string
 	probeAddr               string
+	pprofAddr               string
 	leaderElectionID        string
 	webhookAddr             string
 	certDir                 string
@@ -90,8 +91,9 @@ func Execute() {
 
 func init() {
 	fs := rootCmd.Flags()
-	fs.StringVar(&config.metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to")
+	fs.StringVar(&config.metricsAddr, "metrics-addr", ":8080", "Listen address for metric endpoint")
 	fs.StringVar(&config.probeAddr, "health-probe-addr", ":8081", "Listen address for health probes")
+	fs.StringVar(&config.pprofAddr, "pprof-addr", "", "Listen address for pprof endpoints. pprof is disabled by default")
 	fs.StringVar(&config.leaderElectionID, "leader-election-id", "moco", "ID for leader election by controller-runtime")
 	fs.StringVar(&config.webhookAddr, "webhook-addr", ":9443", "Listen address for the webhook endpoint")
 	fs.StringVar(&config.certDir, "cert-dir", "", "webhook certificate directory")

--- a/cmd/moco-controller/cmd/run.go
+++ b/cmd/moco-controller/cmd/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cybozu-go/moco/pkg/cert"
 	"github.com/cybozu-go/moco/pkg/dbop"
 	"github.com/cybozu-go/moco/pkg/metrics"
+	"github.com/cybozu-go/moco/pkg/pprof"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -134,6 +135,13 @@ func subMain(ns, addr string, port int) error {
 	if err := mgr.AddReadyzCheck("check", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		return err
+	}
+
+	if config.pprofAddr != "" {
+		if err := mgr.Add(pprof.NewHandler(ctrl.Log.WithName("pprof"), config.pprofAddr)); err != nil {
+			setupLog.Error(err, "unable to set pprof handler")
+			return err
+		}
 	}
 
 	metrics.Register(k8smetrics.Registry)

--- a/cmd/moco-controller/cmd/run.go
+++ b/cmd/moco-controller/cmd/run.go
@@ -137,7 +137,7 @@ func subMain(ns, addr string, port int) error {
 		return err
 	}
 
-	if config.pprofAddr != "" {
+	if config.pprofAddr != "" && config.pprofAddr != "0" {
 		if err := mgr.Add(pprof.NewHandler(ctrl.Log.WithName("pprof"), config.pprofAddr)); err != nil {
 			setupLog.Error(err, "unable to set pprof handler")
 			return err

--- a/docs/moco-controller.md
+++ b/docs/moco-controller.md
@@ -29,9 +29,10 @@ Flags:
       --log_file_max_size uint            Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
       --logtostderr                       log to standard error instead of files (default true)
       --max-concurrent-reconciles int     The maximum number of concurrent reconciles which can be run (default 8)
-      --metrics-addr string               The address the metric endpoint binds to (default ":8080")
+      --metrics-addr string               Listen address for metric endpoint (default ":8080")
       --mysqld-exporter-image string      The image of mysqld_exporter sidecar container
       --one_output                        If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+      --pprof-addr string                 Listen address for pprof endpoints. pprof is disabled by default
       --skip_headers                      If true, avoid header prefixes in the log messages
       --skip_log_headers                  If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity          logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -1,0 +1,65 @@
+package pprof
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type Handler struct {
+	log      logr.Logger
+	bindAddr string
+}
+
+var (
+	_ manager.Runnable               = &Handler{}
+	_ manager.LeaderElectionRunnable = &Handler{}
+)
+
+func NewHandler(log logr.Logger, bindAddr string) *Handler {
+	return &Handler{
+		log:      log,
+		bindAddr: bindAddr,
+	}
+}
+
+func (h *Handler) NeedLeaderElection() bool {
+	return false
+}
+
+func (h *Handler) Start(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	server := &http.Server{Addr: h.bindAddr, Handler: mux}
+	errCh := make(chan error)
+	h.log.Info("starting handler", "addr", h.bindAddr)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+	select {
+	case err := <-errCh:
+		// ListenAndServe always returns a non-nil error. So no need for a nil check.
+		h.log.Error(err, "failed to listen")
+		return fmt.Errorf("failed to listen: %w", err)
+	case <-ctx.Done():
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			h.log.Error(err, "failed to shutdown")
+			return fmt.Errorf("failed to shutdown: %v", err)
+		}
+	}
+
+	h.log.Info("shutdown")
+	return nil
+}


### PR DESCRIPTION
Add pprof server to moco-controller.
The pprof server will start only when `--pprof-addr` option is set.

> **Note**
> We can remove the `pprof.Handler` added in this PR after merging the following PR into the controller runtime.
> https://github.com/kubernetes-sigs/controller-runtime/pull/1943

Usage: View the trace data
1. Deploy the moco-controller with `--pprof-addr=:9090` option.
2. Get trace data and run the trace viewer.
    ```bash
    # Get trace data
    $ kubectl port-forward -n moco-system POD_NAME  9090:9090 &
    $ curl -s http://localhost:9090/debug/pprof/trace?seconds=10 > trace.out

    # Run trace viewer
    $ go tool trace -http="localhost:9091" trace.out 
    ```
3. Open `http://localhost:9091` with a Web brower.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>