### PR TITLE
Add id to cluster manager's log

### DIFF
--- a/clustering/log.go
+++ b/clustering/log.go
@@ -1,0 +1,23 @@
+package clustering
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+var defaultLog logr.Logger
+
+// SetDefaultLogger sets the default logger used by the clustering package.
+// The default logger is not normally used. It is used when another
+// logger is not set in context due to testing or programming errors.
+func SetDefaultLogger(log logr.Logger) {
+	defaultLog = log
+}
+
+func logFromContext(ctx context.Context) logr.Logger {
+	if log, err := logr.FromContext(ctx); err == nil {
+		return log
+	}
+	return defaultLog
+}

--- a/clustering/manager_test.go
+++ b/clustering/manager_test.go
@@ -164,7 +164,7 @@ var _ = Describe("manager", func() {
 
 		cluster, err := testGetCluster(ctx)
 		Expect(err).NotTo(HaveOccurred())
-		cm.Update(client.ObjectKeyFromObject(cluster))
+		cm.Update(client.ObjectKeyFromObject(cluster), "test")
 
 		Eventually(func() error {
 			cluster, err = testGetCluster(ctx)
@@ -286,7 +286,7 @@ var _ = Describe("manager", func() {
 
 		cluster, err := testGetCluster(ctx)
 		Expect(err).NotTo(HaveOccurred())
-		cm.Update(client.ObjectKeyFromObject(cluster))
+		cm.Update(client.ObjectKeyFromObject(cluster), "test")
 		defer func() {
 			cm.Stop(client.ObjectKeyFromObject(cluster))
 			time.Sleep(400 * time.Millisecond)
@@ -635,7 +635,7 @@ var _ = Describe("manager", func() {
 
 		cluster, err := testGetCluster(ctx)
 		Expect(err).NotTo(HaveOccurred())
-		cm.Update(client.ObjectKeyFromObject(cluster))
+		cm.Update(client.ObjectKeyFromObject(cluster), "test")
 		defer func() {
 			cm.Stop(client.ObjectKeyFromObject(cluster))
 			time.Sleep(400 * time.Millisecond)
@@ -843,7 +843,7 @@ var _ = Describe("manager", func() {
 			return k8sClient.Status().Update(ctx, cluster)
 		}).Should(Succeed())
 
-		cm.Update(client.ObjectKeyFromObject(cluster))
+		cm.Update(client.ObjectKeyFromObject(cluster), "test")
 
 		Eventually(func() interface{} {
 			return ms.backupTimestamp

--- a/clustering/status.go
+++ b/clustering/status.go
@@ -203,7 +203,7 @@ func (p *managerProcess) GatherStatus(ctx context.Context) (*StatusSet, error) {
 					return
 				}
 				if err != nil {
-					p.log.Error(err, "failed to get mysqld status")
+					logFromContext(ctx).Error(err, "failed to get mysqld status")
 					time.Sleep(statusCheckRetryInterval)
 					continue
 				}

--- a/cmd/moco-controller/cmd/run.go
+++ b/cmd/moco-controller/cmd/run.go
@@ -59,6 +59,7 @@ func subMain(ns, addr string, port int) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&config.zapOpts)))
 	setupLog := ctrl.Log.WithName("setup")
 	clusterLog := ctrl.Log.WithName("cluster-manager")
+	clustering.SetDefaultLogger(clusterLog)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,

--- a/controllers/mock_test.go
+++ b/controllers/mock_test.go
@@ -15,14 +15,14 @@ type mockManager struct {
 
 var _ clustering.ClusterManager = &mockManager{}
 
-func (m *mockManager) Update(key types.NamespacedName) {
+func (m *mockManager) Update(key types.NamespacedName, origin string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.clusters[key.String()] = struct{}{}
 }
 
-func (m *mockManager) UpdateNoStart(key types.NamespacedName) {
+func (m *mockManager) UpdateNoStart(key types.NamespacedName, origin string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -261,7 +261,7 @@ func (r *MySQLClusterReconciler) reconcileV1(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	r.ClusterManager.Update(client.ObjectKeyFromObject(cluster))
+	r.ClusterManager.Update(client.ObjectKeyFromObject(cluster), string(controller.ReconcileIDFromContext(ctx)))
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/pod_watcher.go
+++ b/controllers/pod_watcher.go
@@ -73,7 +73,7 @@ func (r *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	log.Info("detected mysql pod deletion", "name", pod.Name)
-	r.ClusterManager.UpdateNoStart(types.NamespacedName{Namespace: pod.Namespace, Name: ref.Name})
+	r.ClusterManager.UpdateNoStart(types.NamespacedName{Namespace: pod.Namespace, Name: ref.Name}, string(controller.ReconcileIDFromContext(ctx)))
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
This PR fixes the cluster-manager's log.

- Generate an unique string for each cluster-manager's operation. And add it to the log events as `operationId` filed.
- Output log events on start and end for cluster-manager's operation.
- Record the cause of cluster-manager's operation as `origin` field.

After
```json
{"level":"info","ts":"2023-02-08T10:55:39Z","msg":"detected mysql pod deletion","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"moco-single-0","namespace":"foo"},"namespace":"foo","name":"moco-single-0","reconcileID":"dd11da41-a28f-4b3f-9bde-a98bf9cebbbd","name":"moco-single-0"}
{"level":"info","ts":"2023-02-08T10:55:39Z","logger":"cluster-manager.foo/single","msg":"start operation","operationId":"op-6tklf","origin":"dd11da41-a28f-4b3f-9bde-a98bf9cebbbd"}
{"level":"error","ts":"2023-02-08T10:55:44Z","logger":"cluster-manager.foo/single","msg":"failed to get mysqld status","operationId":"op-6tklf","error":"failed to get global variables: pod=moco-single-0, namespace=foo: failed to get mysql global variables: dial tcp 10.244.3.31:33062: i/o timeout","stacktrace":"github.com/cybozu-go/moco/clustering.(*managerProcess).GatherStatus.func2\n\t/work/clustering/status.go:206"}
{"level":"error","ts":"2023-02-08T10:55:52Z","logger":"cluster-manager.foo/single","msg":"failed to get mysqld status","operationId":"op-6tklf","error":"failed to get global variables: pod=moco-single-0, namespace=foo: failed to get mysql global variables: dial tcp 10.244.3.31:33062: i/o timeout","stacktrace":"github.com/cybozu-go/moco/clustering.(*managerProcess).GatherStatus.func2\n\t/work/clustering/status.go:206"}
{"level":"error","ts":"2023-02-08T10:56:00Z","logger":"cluster-manager.foo/single","msg":"failed to get mysqld status","operationId":"op-6tklf","error":"failed to get global variables: pod=moco-single-0, namespace=foo: failed to get mysql global variables: dial tcp 10.244.3.31:33062: i/o timeout","stacktrace":"github.com/cybozu-go/moco/clustering.(*managerProcess).GatherStatus.func2\n\t/work/clustering/status.go:206"}
{"level":"info","ts":"2023-02-08T10:56:03Z","logger":"cluster-manager.foo/single","msg":"update the status information","operationId":"op-6tklf"}
{"level":"info","ts":"2023-02-08T10:56:03Z","logger":"cluster-manager.foo/single","msg":"cluster state is Lost","operationId":"op-6tklf"}
{"level":"info","ts":"2023-02-08T10:56:03Z","logger":"cluster-manager.foo/single","msg":"finish","operationId":"op-6tklf","duration":24.065808786}
{"level":"info","ts":"2023-02-08T10:56:03Z","logger":"cluster-manager.foo/single","msg":"start operation","operationId":"op-bq5jl","origin":"interval"}
{"level":"info","ts":"2023-02-08T10:56:03Z","logger":"cluster-manager.foo/single","msg":"update the status information","operationId":"op-bq5jl"}
{"level":"info","ts":"2023-02-08T10:56:03Z","logger":"cluster-manager.foo/single","msg":"cluster state is Incomplete","operationId":"op-bq5jl"}
{"level":"info","ts":"2023-02-08T10:56:03Z","logger":"cluster-manager.foo/single","msg":"set read_only=0","operationId":"op-bq5jl","instance":0}
{"level":"info","ts":"2023-02-08T10:56:03Z","logger":"cluster-manager.foo/single","msg":"finish","operationId":"op-bq5jl","duration":0.163805937}
```

Before
```json
{"level":"info","ts":"2023-02-08T06:27:59Z","msg":"detected mysql pod deletion","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"moco-single-0","namespace":"foo"},"namespace":"foo","name":"moco-single-0","reconcileID":"18a1933d-b42f-4ec5-82be-d4a1513851dc","name":"moco-single-0"}
{"level":"error","ts":"2023-02-08T06:28:05Z","logger":"cluster-manager.foo/single","msg":"failed to get mysqld status","error":"failed to get global variables: pod=moco-single-0, namespace=foo: failed to get mysql global variables: dial tcp 10.244.2.7:33062: i/o timeout","stacktrace":"github.com/cybozu-go/moco/clustering.(*managerProcess).GatherStatus.func2\n\t/work/clustering/status.go:206"}
{"level":"error","ts":"2023-02-08T06:28:13Z","logger":"cluster-manager.foo/single","msg":"failed to get mysqld status","error":"failed to get global variables: pod=moco-single-0, namespace=foo: failed to get mysql global variables: dial tcp 10.244.2.7:33062: i/o timeout","stacktrace":"github.com/cybozu-go/moco/clustering.(*managerProcess).GatherStatus.func2\n\t/work/clustering/status.go:206"}
{"level":"info","ts":"2023-02-08T06:28:16Z","logger":"cluster-manager.foo/single","msg":"update the status information"}
{"level":"info","ts":"2023-02-08T06:28:16Z","logger":"cluster-manager.foo/single","msg":"cluster state is Lost"}
{"level":"info","ts":"2023-02-08T06:28:16Z","logger":"cluster-manager.foo/single","msg":"update the status information"}
{"level":"info","ts":"2023-02-08T06:28:16Z","logger":"cluster-manager.foo/single","msg":"cluster state is Incomplete"}
{"level":"info","ts":"2023-02-08T06:28:16Z","logger":"cluster-manager.foo/single","msg":"set read_only=0","instance":0}
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>