### PR TITLE
Update fluent-bit v2.0.9

### DIFF
--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ const (
 	Version = "0.14.1"
 
 	// FluentBitImage is the image for slow-log sidecar container.
-	FluentBitImage = "quay.io/cybozu/fluent-bit:1.9.7.2"
+	FluentBitImage = "quay.io/cybozu/fluent-bit:2.0.9.1"
 
 	// ExporterImage is the image for mysqld_exporter sidecar container.
 	ExporterImage = "quay.io/cybozu/mysqld_exporter:0.14.0.2"


### PR DESCRIPTION
Update the default fluent-bit version to v2.0.9 from v1.9.7.

The major version of fluent-bit has gone up, but there are no significant changes to the plugins which MOCO uses.
https://github.com/fluent/fluent-bit/releases/tag/v2.0.0

> **Note**
> MOCO uses the tail input plugin and the file output plugin.
> https://github.com/cybozu-go/moco/blob/v0.14.1/controllers/mysqlcluster_controller.go#L523-L536

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>