### PR TITLE
Wait until all Pods are deleted in E2E

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -47,7 +47,7 @@ endif
 .PHONY: test
 test:
 	env PATH="$$(pwd)/../bin:$$PATH" RUN_E2E=1 \
-		go test -v -race -timeout 20m . -ginkgo.progress -ginkgo.v -ginkgo.failFast
+		go test -v -race -timeout 30m . -ginkgo.progress -ginkgo.v -ginkgo.failFast
 
 .PHONY: test-upgrade
 test-upgrade:

--- a/e2e/backup_test.go
+++ b/e2e/backup_test.go
@@ -166,5 +166,20 @@ var _ = Context("backup", func() {
 
 	It("should delete clusters", func() {
 		kubectlSafe(nil, "delete", "-n", "backup", "mysqlclusters", "--all")
+
+		Eventually(func() error {
+			out, err := kubectl(nil, "get", "-n", "backup", "pod", "-o", "json")
+			if err != nil {
+				return err
+			}
+			pods := &corev1.PodList{}
+			if err := json.Unmarshal(out, pods); err != nil {
+				return err
+			}
+			if len(pods.Items) > 0 {
+				return errors.New("wait until all Pods are deleted")
+			}
+			return nil
+		}).Should(Succeed())
 	})
 })

--- a/e2e/failover_test.go
+++ b/e2e/failover_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -136,5 +137,20 @@ var _ = Context("failure", func() {
 
 	It("should delete clusters", func() {
 		kubectlSafe(nil, "delete", "-n", "failover", "mysqlclusters", "--all")
+
+		Eventually(func() error {
+			out, err := kubectl(nil, "get", "-n", "failover", "pod", "-o", "json")
+			if err != nil {
+				return err
+			}
+			pods := &corev1.PodList{}
+			if err := json.Unmarshal(out, pods); err != nil {
+				return err
+			}
+			if len(pods.Items) > 0 {
+				return errors.New("wait until all Pods are deleted")
+			}
+			return nil
+		}).Should(Succeed())
 	})
 })

--- a/e2e/lifecycle_test.go
+++ b/e2e/lifecycle_test.go
@@ -247,4 +247,23 @@ var _ = Context("lifecycle", func() {
 			return fmt.Errorf("pending services: %+v", services.Items)
 		}).Should(Succeed())
 	})
+
+	It("should delete clusters", func() {
+		kubectlSafe(nil, "delete", "-n", "foo", "mysqlclusters", "--all")
+
+		Eventually(func() error {
+			out, err := kubectl(nil, "get", "-n", "foo", "pod", "-o", "json")
+			if err != nil {
+				return err
+			}
+			pods := &corev1.PodList{}
+			if err := json.Unmarshal(out, pods); err != nil {
+				return err
+			}
+			if len(pods.Items) > 0 {
+				return errors.New("wait until all Pods are deleted")
+			}
+			return nil
+		}).Should(Succeed())
+	})
 })

--- a/e2e/pvc_test.go
+++ b/e2e/pvc_test.go
@@ -197,5 +197,20 @@ var _ = Context("pvc_test", func() {
 
 	It("should delete clusters", func() {
 		kubectlSafe(nil, "delete", "-n", "pvc", "mysqlclusters", "--all")
+
+		Eventually(func() error {
+			out, err := kubectl(nil, "get", "-n", "pvc", "pod", "-o", "json")
+			if err != nil {
+				return err
+			}
+			pods := &corev1.PodList{}
+			if err := json.Unmarshal(out, pods); err != nil {
+				return err
+			}
+			if len(pods.Items) > 0 {
+				return errors.New("wait until all Pods are deleted")
+			}
+			return nil
+		}).Should(Succeed())
 	})
 })

--- a/e2e/replication_test.go
+++ b/e2e/replication_test.go
@@ -346,5 +346,35 @@ var _ = Context("replication", func() {
 	It("should delete clusters", func() {
 		kubectlSafe(nil, "delete", "-n", "donor", "mysqlclusters", "--all")
 		kubectlSafe(nil, "delete", "-n", "repl", "mysqlclusters", "--all")
+
+		Eventually(func() error {
+			out, err := kubectl(nil, "get", "-n", "donor", "pod", "-o", "json")
+			if err != nil {
+				return err
+			}
+			pods := &corev1.PodList{}
+			if err := json.Unmarshal(out, pods); err != nil {
+				return err
+			}
+			if len(pods.Items) > 0 {
+				return errors.New("wait until all Pods are deleted")
+			}
+			return nil
+		}).Should(Succeed())
+
+		Eventually(func() error {
+			out, err := kubectl(nil, "get", "-n", "repl", "pod", "-o", "json")
+			if err != nil {
+				return err
+			}
+			pods := &corev1.PodList{}
+			if err := json.Unmarshal(out, pods); err != nil {
+				return err
+			}
+			if len(pods.Items) > 0 {
+				return errors.New("wait until all Pods are deleted")
+			}
+			return nil
+		}).Should(Succeed())
 	})
 })

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -151,5 +151,20 @@ var _ = Context("upgrade", func() {
 
 	It("should delete clusters", func() {
 		kubectlSafe(nil, "delete", "-n", "upgrade", "mysqlclusters", "--all")
+
+		Eventually(func() error {
+			out, err := kubectl(nil, "get", "-n", "upgrade", "pod", "-o", "json")
+			if err != nil {
+				return err
+			}
+			pods := &corev1.PodList{}
+			if err := json.Unmarshal(out, pods); err != nil {
+				return err
+			}
+			if len(pods.Items) > 0 {
+				return errors.New("wait until all Pods are deleted")
+			}
+			return nil
+		}).Should(Succeed())
 	})
 })


### PR DESCRIPTION
The machine resources available to GitHub Actions runners are limited,
and it has been confirmed that instability due to issues such as OOM can occur when multiple MySQL Cluster pods created for multiple E2E scenarios exist at the same time.
In this PR, we will wait for the pod to disappear during E2E cleanup to avoid exceeding the expected resource usage of the runner.