### PR TITLE
Add podAntiAffinity to MySQL Cluster StatefulSet.

### DIFF
--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -916,6 +916,12 @@ func (r *MySQLClusterReconciler) reconcileV1StatefulSet(ctx context.Context, req
 									WithKey(constants.LabelAppInstance).
 									WithOperator(metav1.LabelSelectorOpIn).
 									WithValues(cluster.Name),
+							).
+							WithMatchExpressions(
+								metav1ac.LabelSelectorRequirement().
+									WithKey(constants.LabelAppCreatedBy).
+									WithOperator(metav1.LabelSelectorOpIn).
+									WithValues(constants.AppCreator),
 							),
 						).
 						WithTopologyKey(corev1.LabelHostname),

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -898,6 +898,32 @@ func (r *MySQLClusterReconciler) reconcileV1StatefulSet(ctx context.Context, req
 	if podSpec.SecurityContext.FSGroupChangePolicy == nil {
 		podSpec.SecurityContext.WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch)
 	}
+	if podSpec.Affinity == nil {
+		podSpec.WithAffinity(corev1ac.Affinity().
+			WithPodAntiAffinity(corev1ac.PodAntiAffinity().
+				WithPreferredDuringSchedulingIgnoredDuringExecution(corev1ac.WeightedPodAffinityTerm().
+					WithWeight(100).
+					WithPodAffinityTerm(corev1ac.PodAffinityTerm().
+						WithLabelSelector(metav1ac.LabelSelector().
+							WithMatchExpressions(
+								metav1ac.LabelSelectorRequirement().
+									WithKey(constants.LabelAppName).
+									WithOperator(metav1.LabelSelectorOpIn).
+									WithValues(constants.AppNameMySQL),
+							).
+							WithMatchExpressions(
+								metav1ac.LabelSelectorRequirement().
+									WithKey(constants.LabelAppInstance).
+									WithOperator(metav1.LabelSelectorOpIn).
+									WithValues(cluster.Name),
+							),
+						).
+						WithTopologyKey(corev1.LabelHostname),
+					),
+				),
+			),
+		)
+	}
 
 	sts.Spec.Template.WithSpec(&podSpec)
 

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -703,6 +703,9 @@ var _ = Describe("MySQLCluster reconciler", func() {
 		Expect(sts.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
 		Expect(*sts.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(int64(constants.ContainerGID)))
 		Expect(*sts.Spec.Template.Spec.SecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
+		Expect(sts.Spec.Template.Spec.Affinity).NotTo(BeNil())
+		Expect(sts.Spec.Template.Spec.Affinity.PodAntiAffinity).NotTo(BeNil())
+		Expect(sts.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).NotTo(BeNil())
 
 		Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(3))
 		foundMysqld := false

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,6 +117,37 @@ spec:
           storage: 1Gi
 ```
 
+By default, MOCO uses `preferredDuringSchedulingIgnoredDuringExecution` to prevent Pods from being placed on the same Node.
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: moco-<MYSQLCLSTER_NAME>
+  namespace: default
+...
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - mysql
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - <MYSQLCLSTER_NAME>
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+...
+```
+
 There are other example manifests in [`examples`](https://github.com/cybozu-go/moco/tree/main/examples) directory.
 
 The complete reference of MySQLCluster is [`crd_mysqlcluster.md`](crd_mysqlcluster.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -139,6 +139,10 @@ spec:
                   operator: In
                   values:
                   - mysql
+                - key: app.kubernetes.io/created-by
+                  operator: In
+                  values:
+                  - moco
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:


### PR DESCRIPTION
* https://github.com/cybozu-go/moco/pull/471

Related to the above pull request, a change will be made to set preferredDuringSchedulingIgnoredDuringExecution as the default configuration in the MySQL Cluster Pod.