### PR TITLE
Fix flaky test

### DIFF
--- a/pkg/dbop/kill_test.go
+++ b/pkg/dbop/kill_test.go
@@ -10,6 +10,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+type process struct {
+	ID    uint64 `db:"ID"`
+	User  string `db:"USER"`
+	Host  string `db:"HOST"`
+	State string `db:"STATE"` // for debugging
+}
+
 var _ = Describe("kill", func() {
 	It("should kill non-system processes only", func() {
 		By("preparing a single node cluster")
@@ -34,35 +41,32 @@ var _ = Describe("kill", func() {
 		defer db.Close()
 
 		By("getting process list")
-		var procs []Process
-		err = op.(*operator).db.Select(&procs, `SELECT ID, USER, HOST FROM information_schema.PROCESSLIST`)
+		var procs []process
+		err = op.(*operator).db.Select(&procs, `SELECT ID, USER, HOST, STATE FROM information_schema.PROCESSLIST`)
 		Expect(err).NotTo(HaveOccurred())
 
-		fooFound := false
 		for _, p := range procs {
-			fmt.Printf("process %d for %s from %s\n", p.ID, p.User, p.Host)
-			if p.User == "foo" {
-				fooFound = true
-			}
+			fmt.Printf("process %d for %s from %s: %s\n", p.ID, p.User, p.Host, p.State)
 		}
-		Expect(fooFound).To(BeTrue())
+		Expect(procs).To(ContainElement(HaveField("User", "foo")))
 
 		By("killing user process")
 		err = op.KillConnections(context.Background())
 		Expect(err).NotTo(HaveOccurred())
 
-		var procs2 []Process
-		err = op.(*operator).db.Select(&procs2, `SELECT ID, USER, HOST FROM information_schema.PROCESSLIST`)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(len(procs) - len(procs2)).To(Equal(1))
+		Eventually(func(g Gomega) {
+			var procs2 []process
+			err := op.(*operator).db.Select(&procs2, `SELECT ID, USER, HOST, STATE FROM information_schema.PROCESSLIST`)
+			g.Expect(err).NotTo(HaveOccurred())
 
-		fooFound = false
-		for _, p := range procs2 {
-			fmt.Printf("process %d for %s from %s\n", p.ID, p.User, p.Host)
-			if p.User == "foo" {
-				fooFound = true
+			// For debugging, print process list before confirming.
+			for _, p := range procs2 {
+				fmt.Printf("process %d for %s from %s: %s\n", p.ID, p.User, p.Host, p.State)
 			}
-		}
-		Expect(fooFound).To(BeFalse())
+			fmt.Println("")
+
+			g.Expect(procs2).To(HaveLen(len(procs) - 1))
+			g.Expect(procs2).NotTo(ContainElement(HaveField("User", "foo")))
+		}).Should(Succeed())
 	})
 })


### PR DESCRIPTION
This PR fixes a flaky test of killing process.

There is a time lag until processes are actually deleted after the `KILL CONNECTION` command.
So I use `Eventually` and waite for the deletion.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>