### PR TITLE
Stop releasing ARM64 image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
       with:
-        platforms: linux/amd64,linux/arm64/v8
+        platforms: linux/amd64
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
@@ -37,7 +37,7 @@ jobs:
       with:
         builder: ${{ steps.buildx.outputs.name }}
         push: true
-        platforms: linux/amd64,linux/arm64/v8
+        platforms: linux/amd64
         tags: ${{ steps.meta.outputs.tags }}
         target: controller
         labels: ${{ steps.meta.outputs.labels }}
@@ -51,7 +51,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
       with:
-        platforms: linux/amd64,linux/arm64/v8
+        platforms: linux/amd64
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
@@ -76,7 +76,7 @@ jobs:
       with:
         builder: ${{ steps.buildx.outputs.name }}
         push: true
-        platforms: linux/amd64,linux/arm64/v8
+        platforms: linux/amd64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha


### PR DESCRIPTION
The moco-backup image cannot be built for linux/arm64.
So I will stop releasing ARM64 images.

When releasing MOCO v0.16.0, I failed to build the moco-backup image.
I tried to fix it but could not immediately because the mysql-shell for linux/arm64 is not provided on the official site.

https://github.com/cybozu-go/moco/actions/runs/4627054740/jobs/8184735343

```
 > [linux/arm64 stage-3 6/6] RUN apt-get update   && apt-get install -y --no-install-recommends libjemalloc2 zstd python3 libpython3.8 s3cmd   && rm -rf /var/lib/apt/lists/*   && curl -o /tmp/mysqlsh.deb -fsL https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell_8.0.30-1ubuntu20.04_amd64.deb   && dpkg -i /tmp/mysqlsh.deb   && rm -f /tmp/mysqlsh.deb:
#25 63.01 Setting up python3-six (1.14.0-2) ...
#25 65.34 Setting up libpython3.8:arm64 (3.8.10-0ubuntu1~20.04.7) ...
#25 65.35 Setting up python3-dateutil (2.7.3-3ubuntu1) ...
#25 67.93 Setting up python3-magic (2:0.4.15-3) ...
#25 70.29 Setting up s3cmd (2.0.2-1ubuntu1) ...
#25 73.02 Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
#25 76.40 dpkg: error processing archive /tmp/mysqlsh.deb (--install):
#25 76.40  package architecture (amd64) does not match system (arm64)
#25 76.46 Errors were encountered while processing:
#25 76.46  /tmp/mysqlsh.deb
------
Dockerfile:37
--------------------
  36 |     
  37 | >>> RUN apt-get update \
  38 | >>>   && apt-get install -y --no-install-recommends libjemalloc2 zstd python3 libpython3.8 s3cmd \
  39 | >>>   && rm -rf /var/lib/apt/lists/* \
  40 | >>>   && curl -o /tmp/mysqlsh.deb -fsL https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell_${MYSQLSH_VERSION}ubuntu20.04_amd64.deb \
  41 | >>>   && dpkg -i /tmp/mysqlsh.deb \
  42 | >>>   && rm -f /tmp/mysqlsh.deb
  43 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update   && apt-get install -y --no-install-recommends libjemalloc2 zstd python3 libpython3.8 s3cmd   && rm -rf /var/lib/apt/lists/*   && curl -o /tmp/mysqlsh.deb -fsL https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell_${MYSQLSH_VERSION}ubuntu20.04_amd64.deb   && dpkg -i /tmp/mysqlsh.deb   && rm -f /tmp/mysqlsh.deb" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c apt-get update   && apt-get install -y --no-install-recommends libjemalloc2 zstd python3 libpython3.8 s3cmd   && rm -rf /var/lib/apt/lists/*   && curl -o /tmp/mysqlsh.deb -fsL https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell_${MYSQLSH_VERSION}ubuntu20.04_amd64.deb   && dpkg -i /tmp/mysqlsh.deb   && rm -f /tmp/mysqlsh.deb" did not complete successfully: exit code: 1
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>