### PR TITLE
Disable innodb_undo_log_truncate

### DIFF
--- a/pkg/mycnf/generator.go
+++ b/pkg/mycnf/generator.go
@@ -90,6 +90,10 @@ var DefaultMycnf = map[string]string{
 	"innodb_random_read_ahead":    "false",
 	"innodb_read_ahead_threshold": "0",
 	"innodb_log_write_ahead_size": "512",
+
+	// Disabled because of https://bugs.mysql.com/bug.php?id=104573
+	// The undo log truncate always fails on replica instances of `super_read_only = 1`.
+	"innodb_undo_log_truncate": "OFF",
 }
 
 // ConstMycnf is the mysqld configurations that MOCO applies forcibly.

--- a/pkg/mycnf/testdata/bufsize.cnf
+++ b/pkg/mycnf/testdata/bufsize.cnf
@@ -37,6 +37,7 @@ innodb_print_all_deadlocks = 1
 innodb_random_read_ahead = false
 innodb_read_ahead_threshold = 0
 innodb_tmpdir = /tmp
+innodb_undo_log_truncate = OFF
 join_buffer_size = 2M
 lock_wait_timeout = 60
 log_error_verbosity = 3

--- a/pkg/mycnf/testdata/loose.cnf
+++ b/pkg/mycnf/testdata/loose.cnf
@@ -38,6 +38,7 @@ innodb_print_all_deadlocks = 1
 innodb_random_read_ahead = false
 innodb_read_ahead_threshold = 0
 innodb_tmpdir = /tmp
+innodb_undo_log_truncate = OFF
 join_buffer_size = 2M
 lock_wait_timeout = 60
 log_error_verbosity = 3

--- a/pkg/mycnf/testdata/nil.cnf
+++ b/pkg/mycnf/testdata/nil.cnf
@@ -37,6 +37,7 @@ innodb_print_all_deadlocks = 1
 innodb_random_read_ahead = false
 innodb_read_ahead_threshold = 0
 innodb_tmpdir = /tmp
+innodb_undo_log_truncate = OFF
 join_buffer_size = 2M
 lock_wait_timeout = 60
 log_error_verbosity = 3

--- a/pkg/mycnf/testdata/normalize.cnf
+++ b/pkg/mycnf/testdata/normalize.cnf
@@ -38,6 +38,7 @@ innodb_print_all_deadlocks = 1
 innodb_random_read_ahead = false
 innodb_read_ahead_threshold = 0
 innodb_tmpdir = /tmp
+innodb_undo_log_truncate = OFF
 join_buffer_size = 2M
 lock_wait_timeout = 60
 log_error_verbosity = 3

--- a/pkg/mycnf/testdata/opaque.cnf
+++ b/pkg/mycnf/testdata/opaque.cnf
@@ -42,6 +42,7 @@ innodb_print_all_deadlocks = 1
 innodb_random_read_ahead = false
 innodb_read_ahead_threshold = 0
 innodb_tmpdir = /tmp
+innodb_undo_log_truncate = OFF
 join_buffer_size = 2M
 lock_wait_timeout = 60
 log_error_verbosity = 3


### PR DESCRIPTION
refs https://github.com/cybozu-go/moco/issues/530

This PR disables `innodb_undo_log_truncate` by default.
Because the `undo log truncate` always fails on replica instances which are `set super_read_only = 1`.

https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_undo_log_truncate
https://bugs.mysql.com/bug.php?id=104573

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>