### PR TITLE
Remove resoruces overwrite in e2e

### DIFF
--- a/e2e/lifecycle_test.go
+++ b/e2e/lifecycle_test.go
@@ -45,6 +45,23 @@ var _ = Context("lifecycle", func() {
 		}).Should(Succeed())
 	})
 
+	It("should give a pod the guarranteed QoS class", func() {
+		Eventually(func() error {
+			out, err := kubectl(nil, "get", "-n", "foo", "pod", "moco-single-0", "-o", "json")
+			if err != nil {
+				return err
+			}
+			pod := &corev1.Pod{}
+			if err := json.Unmarshal(out, pod); err != nil {
+				return err
+			}
+			if pod.Status.QOSClass != corev1.PodQOSGuaranteed {
+				return fmt.Errorf("mysql pod is not the Guarranteed QoS class: %s", pod.Status.QOSClass)
+			}
+			return nil
+		}).Should(Succeed())
+	})
+
 	It("should log slow queries via sidecar", func() {
 		out := kubectlSafe(nil, "moco", "-n", "foo", "mysql", "single", "--", "-N", "-e", "SELECT @@long_query_time")
 		val, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)

--- a/e2e/testdata/backup.yaml
+++ b/e2e/testdata/backup.yaml
@@ -52,24 +52,6 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ . }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/backup_gcs.yaml
+++ b/e2e/testdata/backup_gcs.yaml
@@ -49,24 +49,6 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ . }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/donor.yaml
+++ b/e2e/testdata/donor.yaml
@@ -23,23 +23,6 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ . }}
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/failover.yaml
+++ b/e2e/testdata/failover.yaml
@@ -15,24 +15,6 @@ spec:
       containers:
         - name: mysqld
           image: quay.io/cybozu/mysql:{{ . }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
     - metadata:
         name: mysql-data

--- a/e2e/testdata/failure.yaml
+++ b/e2e/testdata/failure.yaml
@@ -15,24 +15,6 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ . }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/pvc_test.yaml
+++ b/e2e/testdata/pvc_test.yaml
@@ -33,24 +33,6 @@ spec:
       containers:
         - name: mysqld
           image: quay.io/cybozu/mysql:{{ . }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
     - metadata:
         name: mysql-data

--- a/e2e/testdata/pvc_test_changed.yaml
+++ b/e2e/testdata/pvc_test_changed.yaml
@@ -11,24 +11,6 @@ spec:
       containers:
         - name: mysqld
           image: quay.io/cybozu/mysql:{{ . }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
     - metadata:
         name: mysql-data

--- a/e2e/testdata/replication.yaml
+++ b/e2e/testdata/replication.yaml
@@ -25,24 +25,6 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ . }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/restore.yaml
+++ b/e2e/testdata/restore.yaml
@@ -28,24 +28,6 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ .MySQLVersion }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/restore_gcs.yaml
+++ b/e2e/testdata/restore_gcs.yaml
@@ -25,24 +25,6 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ .MySQLVersion }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/single.yaml
+++ b/e2e/testdata/single.yaml
@@ -24,6 +24,10 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ . }}
+        resources:
+          limits:
+            cpu: "0.5"
+            memory: 1Gi
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/single.yaml
+++ b/e2e/testdata/single.yaml
@@ -24,24 +24,6 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ . }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/upgrade.yaml
+++ b/e2e/testdata/upgrade.yaml
@@ -15,24 +15,6 @@ spec:
       containers:
       - name: mysqld
         image: quay.io/cybozu/mysql:{{ . }}
-    # Specify minimum resources so as not to overwhelm CI resources.
-    overwriteContainers:
-      - name: agent
-        resources:
-          requests:
-            cpu: 1m
-      - name: moco-init
-        resources:
-          requests:
-            cpu: 1m
-      - name: slow-log
-        resources:
-          requests:
-            cpu: 1m
-      - name: mysqld-exporter
-        resources:
-          requests:
-            cpu: 1m
   volumeClaimTemplates:
   - metadata:
       name: mysql-data


### PR DESCRIPTION
With this PR https://github.com/cybozu-go/moco/pull/510, now we delete used MySQLClusters at the end of each test case.
Thus, we can run tests with default resource requests.

In addition, I will add a test to confirm that a MySQLCluster is configurable for guarranteed QoS.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>