### PR TITLE
Set kubeVersion compatible with EKS

### DIFF
--- a/charts/moco/Chart.yaml
+++ b/charts/moco/Chart.yaml
@@ -26,4 +26,4 @@ appVersion: 0.16.1
 # This version does not necessarily match the supported version. This version number
 # will be updated when there is an obviously uninstallable version. If there are no
 # problems, update only moco/README.md#supported-software for the corresponding kubernetes version.
-kubeVersion: ">= 1.22.0"
+kubeVersion: ">= 1.22.0-0"


### PR DESCRIPTION
AWS EKS version syntax is 1.27.3-eks-a5565ad which leads to errors like :
Error: chart requires kubeVersion: >= 1.22.0 which is incompatible with Kubernetes v1.27.3-eks-a5565ad

This PR set version compatibility as EKS friendly.