### PR TITLE
Use image hosted on ghcr.io

### DIFF
--- a/.github/workflows/build-mysql-container.yaml
+++ b/.github/workflows/build-mysql-container.yaml
@@ -36,12 +36,7 @@ jobs:
 
           done
 
-          if [ "${#array[@]}" -eq 0 ]; then
-            json_output="[]"
-          else
-            json_output=$(printf '%s\n' "${array[@]}" | jq -R . | jq -s . | jq -c .)
-          fi
-
+          json_output=$(echo "${array[@]}" | jq -Rc 'split(" ")')
           echo "GITHUB_OUTPUT: mysql-versions=$json_output"
           echo "mysql-versions=$json_output" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-mysql-container.yaml
+++ b/.github/workflows/build-mysql-container.yaml
@@ -15,15 +15,50 @@ on:
       - "!**.md"
 
 jobs:
+  filter:
+    runs-on: ubuntu-20.04
+    outputs:
+      mysql-versions: ${{ steps.filter.outputs.mysql-versions }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: filter
+        id: filter
+        working-directory: containers
+        run: |
+          array=()
+
+          for dir in $(find ./mysql -mindepth 1 -type d -printf '%f\n'); do
+            result=$(./tag_exists moco/mysql "mysql/$dir")
+
+            if [ "$result" = 'ng' ]; then
+              array+=( "$dir" )
+            fi
+
+          done
+
+          if [ "${#array[@]}" -eq 0 ]; then
+            json_output="[]"
+          else
+            json_output=$(printf '%s\n' "${array[@]}" | jq -R . | jq -s . | jq -c .)
+          fi
+
+          echo "GITHUB_OUTPUT: mysql-versions=$json_output"
+          echo "mysql-versions=$json_output" >> "$GITHUB_OUTPUT"
+
   tests:
-    if: github.event_name == 'pull_request'
+    if: ${{ (github.event_name == 'pull_request') && (needs.filter.outputs.mysql-versions != '[]') }}
+    needs: filter
     runs-on: ${{ vars.IMAGE_BUILD_RUNNER || 'ubuntu-20.04' }}
     strategy:
       matrix:
-        mysql-version: [ "8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30", "8.0.31", "8.0.32" ]
+        mysql-version: ${{ fromJson(needs.filter.outputs.mysql-versions) }}
         k8s-version: [ "1.27.1" ]
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true
       - uses: docker/setup-buildx-action@v2
         with:
           driver: docker # refs: https://github.com/docker/build-push-action/issues/321
@@ -56,54 +91,34 @@ jobs:
         run: |
           container-structure-test test --image ghcr.io/cybozu-go/moco/mysql:${{ matrix.mysql-version }} --config ./containers/mysql/${{ matrix.mysql-version }}/container-structure-test.yaml
 
-      - name: Create kind cluster
-        run: kind create cluster --name=moco --config=./e2e/kind-config_actions.yaml --image=kindest/node:v${{ matrix.k8s-version }} --wait 1m
+      - run: |
+          swapon > swapon.txt
+          sudo swapoff -a
+          cat swapon.txt | tail -n+2 | awk '$2=="file" {print $1}' | sudo xargs --no-run-if-empty rm
+      - run: sudo mkdir /mnt/local-path-provisioner0 /mnt/local-path-provisioner1 /mnt/local-path-provisioner2
 
-      - name: Load mysqld image
-        run: kind load docker-image ghcr.io/cybozu-go/moco/mysql:${{ matrix.mysql-version }} --name moco
+      - name: Setup test cluster with local mysql image
+        run: make start KUBERNETES_VERSION=${{ matrix.k8s-version }} MYSQL_VERSION=${{ matrix.mysql-version }} KIND_CONFIG=kind-config_actions.yaml USE_LOCAL_MYSQL_IMAGE=1
+        working-directory: e2e
 
-      - name: Install MOCO
-        run: |
-          kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
-          kubectl -n cert-manager wait --for=condition=available --timeout=180s --all deployments
-          kubectl apply -f https://github.com/cybozu-go/moco/releases/latest/download/moco.yaml
-          kubectl -n moco-system wait --for=condition=available --timeout=180s --all deployments
-
-      - name: Create MySQLCluster
-        run: |
-          cat > mycluster.yaml <<'EOF'
-          apiVersion: moco.cybozu.com/v1beta1
-          kind: MySQLCluster
-          metadata:
-            namespace: default
-            name: test
-          spec:
-            replicas: 3
-            podTemplate:
-              spec:
-                containers:
-                  - name: mysqld
-                    image: ghcr.io/cybozu-go/moco/mysql:${{ matrix.mysql-version }}
-            volumeClaimTemplates:
-              - metadata:
-                  name: mysql-data
-                spec:
-                  accessModes: [ "ReadWriteOnce" ]
-                  resources:
-                    requests:
-                      storage: 1Gi
-          EOF
-          kubectl apply -f mycluster.yaml
-
-      - name: Wait for MySQLCluster
-        run: kubectl wait -n default --for=condition=Available mysqlcluster/test --timeout=180s
+      - run: make test
+        working-directory: e2e
+      - run: make logs
+        working-directory: e2e
+        if: always()
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: logs-${{ inputs.k8s-version }}-${{ inputs.mysql-version }}.tar.gz
+          path: e2e/logs.tar.gz
 
   build:
-    if: github.ref == 'refs/heads/main'
+    if: ${{ (github.ref == 'refs/heads/main') && (needs.filter.outputs.mysql-versions != '[]') }}
+    needs: filter
     runs-on: ${{ vars.IMAGE_BUILD_RUNNER || 'ubuntu-20.04' }}
     strategy:
       matrix:
-        mysql-version: [ "8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30", "8.0.31", "8.0.32" ]
+        mysql-version: ${{ fromJson(needs.filter.outputs.mysql-versions) }}
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build-mysql-container.yaml
+++ b/.github/workflows/build-mysql-container.yaml
@@ -63,14 +63,13 @@ jobs:
         with:
           driver: docker # refs: https://github.com/docker/build-push-action/issues/321
 
-      - name: Check TAG file
+      - name: Export TAG file
+        id: tag
         working-directory: containers
         run: |
-          result="$(./tag_exists moco/mysql mysql/${{ matrix.mysql-version }})"
-          if [ "$result" = ok ]; then
-            exit 1
-          fi
-          echo "TAG=$(cat ./mysql/${{ matrix.mysql-version }}/TAG)" >> $GITHUB_ENV
+          TAG=$(cat ./mysql/${{ matrix.mysql-version }}/TAG)
+          echo "tag: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - uses: docker/build-push-action@v4
         with:
@@ -78,7 +77,7 @@ jobs:
           push: false
           load: true
           tags: |
-            ghcr.io/cybozu-go/moco/mysql:${{ env.TAG }}
+            ghcr.io/cybozu-go/moco/mysql:${{ steps.tag.outputs.tag }}
             ghcr.io/cybozu-go/moco/mysql:${{ matrix.mysql-version }}
 
       - name: Install Container Structure Tests
@@ -109,7 +108,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: logs-${{ inputs.k8s-version }}-${{ inputs.mysql-version }}.tar.gz
+          name: logs-${{ matrix.k8s-version }}-${{ matrix.mysql-version }}.tar.gz
           path: e2e/logs.tar.gz
 
   build:
@@ -130,14 +129,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check TAG file
+      - name: Export TAG file
+        id: tag
         working-directory: containers
         run: |
-          result="$(./tag_exists moco/mysql mysql/${{ matrix.mysql-version }})"
-          if [ "$result" = ok ]; then
-            exit 1
-          fi
-          echo "TAG=$(cat ./mysql/${{ matrix.mysql-version }}/TAG)" >> $GITHUB_ENV
+          TAG=$(cat ./mysql/${{ matrix.mysql-version }}/TAG)
+          echo "tag: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - uses: docker/build-push-action@v4
         with:
@@ -147,5 +145,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ghcr.io/cybozu-go/moco/mysql:${{ env.TAG }}
+            ghcr.io/cybozu-go/moco/mysql:${{ steps.tag.outputs.tag }}
             ghcr.io/cybozu-go/moco/mysql:${{ matrix.mysql-version }}

--- a/.github/workflows/build-mysql-container.yaml
+++ b/.github/workflows/build-mysql-container.yaml
@@ -29,11 +29,9 @@ jobs:
 
           for dir in $(find ./mysql -mindepth 1 -type d -printf '%f\n'); do
             result=$(./tag_exists moco/mysql "mysql/$dir")
-
             if [ "$result" = 'ng' ]; then
               array+=( "$dir" )
             fi
-
           done
 
           json_output=$(echo "${array[@]}" | jq -Rc 'split(" ")')

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,8 @@ jobs:
           sudo swapoff -a
           cat swapon.txt | tail -n+2 | awk '$2=="file" {print $1}' | sudo xargs --no-run-if-empty rm
       - run: sudo mkdir /mnt/local-path-provisioner0 /mnt/local-path-provisioner1 /mnt/local-path-provisioner2
-      - run: make start KUBERNETES_VERSION=${{ inputs.k8s-version }} MYSQL_VERSION=${{ inputs.mysql-version }} KIND_CONFIG=kind-config_actions.yaml
+      - name: Setup test cluster
+        run: make start KUBERNETES_VERSION=${{ inputs.k8s-version }} MYSQL_VERSION=${{ inputs.mysql-version }} KIND_CONFIG=kind-config_actions.yaml
         working-directory: e2e
       - run: make test
         working-directory: e2e

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -58,7 +58,7 @@ Edit the following lines in `Dockerfile`:
 
 ```
 # The tag should be the latest one
-FROM quay.io/cybozu/mysql:8.0.30.1 as mysql
+FROM ghcr.io/cybozu-go/moco/mysql:8.0.30.1 as mysql
 
 # See the below description for how to get the version string.
 ARG MYSQLSH_VERSION=8.0.30-1

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ USER 10000:10000
 ENTRYPOINT ["/moco-controller"]
 
 # For MySQL binaries
-FROM --platform=$TARGETPLATFORM quay.io/cybozu/mysql:8.0.32.1 as mysql
+FROM --platform=$TARGETPLATFORM ghcr.io/cybozu-go/moco/mysql:8.0.32.1 as mysql
 
 # the backup image
 FROM --platform=$TARGETPLATFORM quay.io/cybozu/ubuntu:20.04

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -118,5 +118,41 @@ This will prevent the MOCO version from going up just by modifying the Helm Char
     $ git push origin chart-v$CHARTVERSION
     ```
 
+## Container Image Release
+
+This repository manages the following container images that MOCO uses:
+
+* [MySQL](./containers/mysql)
+* [fluent-bit](./containers/fluent-bit)
+* [mysqld_exporter](./containers/mysqld_exporter)
+
+If you want to release these images, edit the TAG file.
+
+e.g. [containers/mysql/8.0.32/TAG](./containers/mysql/8.0.32/TAG)
+
+When a commit changing the TAG file is merged into the main branch, the release of the container image is executed.
+If the TAG file is not changed, the release will not be executed even if you edit the Dockerfile.
+
+### Tag naming
+
+Images whose upstream version conform to [Semantic Versioning 2.0.0][semver] should be
+tagged like this:
+
+    Upstream version + "." + Container image version
+
+For example, if the upstream version is `X.Y.Z`, the first image for this version will
+be tagged as `X.Y.Z.1`.  Likewise, if the upstream version has pre-release part like
+`X.Y.Z-beta.3`, the tag will be `X.Y.Z-beta.3.1`.
+The container image version will be incremented when some changes are introduced to the image.
+
+If the upstream version has no patch version (`X.Y`), fill the patch version with 0 then
+add the container image version _A_ (`X.Y.0.A`).
+
+The container image version _must_ be reset to 1 when the upstream version is changed.
+
+#### Example
+
+If the upstream version is "1.2.0-beta.3", the image tag must begin with "1.2.0-beta.3.1".
+
 [semver]: https://semver.org/spec/v2.0.0.html
 [example]: https://github.com/cybozu-go/etcdpasswd/commit/77d95384ac6c97e7f48281eaf23cb94f68867f79

--- a/docs/custom-mysqld.md
+++ b/docs/custom-mysqld.md
@@ -1,6 +1,6 @@
 # Building custom image of `mysqld`
 
-There are pre-built `mysqld` container images for MOCO on [`quay.io/cybozu/mysql`](https://quay.io/repository/cybozu/mysql?tag=latest&tab=tags).
+There are pre-built `mysqld` container images for MOCO on [`ghcr.io/cybozu-go/moco/mysql`](https://github.com/cybozu-go/moco/pkgs/container/moco%2Fmysql).
 Users can use one of these images to supply `mysqld` container in [MySQLCluster](crd_mysqlcluster.md) like:
 
 ```yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
 ```
 
 If you want to build and use your own `mysqld`, read the rest of this document.

--- a/docs/customize-system-container.md
+++ b/docs/customize-system-container.md
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
     overwriteContainers:
     - name: agent
       resources:

--- a/docs/designdoc/allow_customize_containers.md
+++ b/docs/designdoc/allow_customize_containers.md
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
     overwriteContainers:
     - name: agent
       resources:
@@ -95,7 +95,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
     overwriteContainers:
       agent:
         resources:

--- a/docs/designdoc/support_reduce_volume_size.md
+++ b/docs/designdoc/support_reduce_volume_size.md
@@ -45,7 +45,7 @@ For example, the user modifies the `.spec.volumeClaimTemplates` of the MySQLClus
       spec:
         containers:
         - name: mysqld
-          image: quay.io/cybozu/mysql:8.0.30
+          image: ghcr.io/cybozu-go/moco/mysql:8.0.30
     volumeClaimTemplates:
     - metadata:
         name: mysql-data

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,7 +99,7 @@ spec:
       containers:
       # At least a container named "mysqld" must be defined.
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
         # By limiting CPU and memory, Pods will have Guaranteed QoS class.
         # requests can be omitted; it will be set to the same value as limits.
         resources:
@@ -207,7 +207,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30  # must be the same version as the donor
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30  # must be the same version as the donor
   volumeClaimTemplates:
   - metadata:
       name: mysql-data
@@ -222,7 +222,7 @@ To stop the replication from the donor, update MySQLCluster with `spec.replicati
 
 ### Bring your own image
 
-We provide pre-built MySQL container images at [quay.io/cybozu/mysql](http://quay.io/cybozu/mysql).
+We provide pre-built MySQL container images at [ghcr.io/cybozu-go/moco/mysql](https://github.com/cybozu-go/moco/pkgs/container/moco%2Fmysql).
 If you want to build and use your own image, read [`custom-mysqld.md`](custom-mysqld.md).
 
 ## Configurations
@@ -695,7 +695,7 @@ spec:
       containers:
       - name: mysqld
         # Edit the next line
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
 ```
 
 You are advised to make backups and/or create a replica cluster before starting the upgrade process.

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -14,6 +14,9 @@ export MYSQL_VERSION KUBECTL KUBECONFIG
 AGENT_DIR =
 AGENT_IMAGE := ghcr.io/cybozu-go/moco-agent:$(shell awk '/moco-agent/ {print substr($$2, 2)}' ../go.mod)
 
+## to test development version of mysqld, run make with USE_LOCAL_MYSQL_IMAGE=1
+USE_LOCAL_MYSQL_IMAGE =
+
 ## We need to switch the configuration of kind on GitHub Actions
 KIND_CONFIG = kind-config.yaml
 
@@ -36,6 +39,9 @@ start: $(KIND) $(KUBECTL) $(KUSTOMIZE) $(KUBECTL_MOCO)
 ifdef AGENT_DIR
 	cd $(AGENT_DIR); docker buildx build --load --no-cache -t $(AGENT_IMAGE) .
 	$(KIND) load docker-image $(AGENT_IMAGE) --name=moco
+endif
+ifdef USE_LOCAL_MYSQL_IMAGE
+	$(KIND) load docker-image ghcr.io/cybozu-go/moco/mysql:$(MYSQL_VERSION) --name=moco
 endif
 	$(KUBECTL) apply -f https://github.com/jetstack/cert-manager/releases/download/v$(CERT_MANAGER_VERSION)/cert-manager.yaml
 	$(KUBECTL) -n cert-manager wait --for=condition=available --timeout=180s --all deployments

--- a/e2e/testdata/backup.yaml
+++ b/e2e/testdata/backup.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:{{ . }}
+        image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/backup_gcs.yaml
+++ b/e2e/testdata/backup_gcs.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:{{ . }}
+        image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/client.yaml
+++ b/e2e/testdata/client.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   containers:
   - name: pause
-    image: quay.io/cybozu/mysql:{{ . }}
+    image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
     command: ["pause"]

--- a/e2e/testdata/donor.yaml
+++ b/e2e/testdata/donor.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:{{ . }}
+        image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/failover.yaml
+++ b/e2e/testdata/failover.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: mysqld
-          image: quay.io/cybozu/mysql:{{ . }}
+          image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
   volumeClaimTemplates:
     - metadata:
         name: mysql-data

--- a/e2e/testdata/failure.yaml
+++ b/e2e/testdata/failure.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:{{ . }}
+        image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/pvc_test.yaml
+++ b/e2e/testdata/pvc_test.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: mysqld
-          image: quay.io/cybozu/mysql:{{ . }}
+          image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
   volumeClaimTemplates:
     - metadata:
         name: mysql-data

--- a/e2e/testdata/pvc_test_changed.yaml
+++ b/e2e/testdata/pvc_test_changed.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: mysqld
-          image: quay.io/cybozu/mysql:{{ . }}
+          image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
   volumeClaimTemplates:
     - metadata:
         name: mysql-data

--- a/e2e/testdata/replication.yaml
+++ b/e2e/testdata/replication.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:{{ . }}
+        image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/restore.yaml
+++ b/e2e/testdata/restore.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:{{ .MySQLVersion }}
+        image: ghcr.io/cybozu-go/moco/mysql:{{ .MySQLVersion }}
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/restore_gcs.yaml
+++ b/e2e/testdata/restore_gcs.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:{{ .MySQLVersion }}
+        image: ghcr.io/cybozu-go/moco/mysql:{{ .MySQLVersion }}
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/e2e/testdata/single.yaml
+++ b/e2e/testdata/single.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:{{ . }}
+        image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
         resources:
           limits:
             cpu: "0.5"

--- a/e2e/testdata/upgrade.yaml
+++ b/e2e/testdata/upgrade.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:{{ . }}
+        image: ghcr.io/cybozu-go/moco/mysql:{{ . }}
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/examples/anti-affinity.yaml
+++ b/examples/anti-affinity.yaml
@@ -26,7 +26,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
         resources:
           requests:
             cpu: "10"

--- a/examples/collect-metrics.yaml
+++ b/examples/collect-metrics.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/examples/custom-mycnf.yaml
+++ b/examples/custom-mycnf.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/examples/custom-probe.yaml
+++ b/examples/custom-probe.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: mysqld
-          image: quay.io/cybozu/mysql:8.0.30
+          image: ghcr.io/cybozu-go/moco/mysql:8.0.30
           # If you want to override the default probes, you cannot override the httpGet.
           livenessProbe:
             failureThreshold: 3

--- a/examples/guaranteed.yaml
+++ b/examples/guaranteed.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
         # By limiting CPU and memory, Pods will have Guaranteed QoS class.
         # requests can be omitted; it will be set to the same value as limits.
         resources:

--- a/examples/loadbalancer.yaml
+++ b/examples/loadbalancer.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: mysqld
-        image: quay.io/cybozu/mysql:8.0.30
+        image: ghcr.io/cybozu-go/moco/mysql:8.0.30
   volumeClaimTemplates:
   - metadata:
       name: mysql-data

--- a/version.go
+++ b/version.go
@@ -5,8 +5,8 @@ const (
 	Version = "0.16.1"
 
 	// FluentBitImage is the image for slow-log sidecar container.
-	FluentBitImage = "quay.io/cybozu/fluent-bit:2.0.9.1"
+	FluentBitImage = "ghcr.io/cybozu-go/moco/fluent-bit:2.0.9.1"
 
 	// ExporterImage is the image for mysqld_exporter sidecar container.
-	ExporterImage = "quay.io/cybozu/mysqld_exporter:0.14.0.4"
+	ExporterImage = "ghcr.io/cybozu-go/moco/mysqld_exporter:0.14.0.1"
 )


### PR DESCRIPTION
* https://github.com/cybozu-go/moco/issues/535

Use image hosted on `ghcr.io`.

We also use a local mysql image to run E2E tests after building the MySQL image.
This allows more detailed testing of the built mysql image.
