### PR TITLE
Updating mysqld_exporter and fluent-bit images used in moco

### DIFF
--- a/version.go
+++ b/version.go
@@ -5,8 +5,8 @@ const (
 	Version = "0.16.1"
 
 	// FluentBitImage is the image for slow-log sidecar container.
-	FluentBitImage = "ghcr.io/cybozu-go/moco/fluent-bit:2.0.9.1"
+	FluentBitImage = "ghcr.io/cybozu-go/moco/fluent-bit:2.1.8.2"
 
 	// ExporterImage is the image for mysqld_exporter sidecar container.
-	ExporterImage = "ghcr.io/cybozu-go/moco/mysqld_exporter:0.14.0.1"
+	ExporterImage = "ghcr.io/cybozu-go/moco/mysqld_exporter:0.15.0.2"
 )


### PR DESCRIPTION
Update `version.go` to use the containers built in #553 