### PR TITLE
Fix log message when demote annotation is added

### DIFF
--- a/controllers/pod_watcher.go
+++ b/controllers/pod_watcher.go
@@ -72,7 +72,11 @@ func (r *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("detected mysql pod deletion", "name", pod.Name)
+	if pod.DeletionTimestamp != nil {
+		log.Info("detected mysql pod deletion", "name", pod.Name)
+	} else {
+		log.Info("detected demote annotation", "name", pod.Name)
+	}
 	r.ClusterManager.UpdateNoStart(types.NamespacedName{Namespace: pod.Namespace, Name: ref.Name}, string(controller.ReconcileIDFromContext(ctx)))
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
This PR fixes the log message when `kubectl moco switchover` is executed.

The current message is confusing because the controller outputs `detected mysql pod deletion` even though the pod has not been deleted.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>