### PR TITLE
backup: PITR did not work sometimes

### DIFF
--- a/backup/restore_test.go
+++ b/backup/restore_test.go
@@ -15,6 +15,10 @@ func TestFindNearestDump(t *testing.T) {
 		"moco/test/test/garbage",
 		"moco/test/test/20210526000000/dump.tar", // invalid
 		"moco/test/test/20210526-000000/dump.tar",
+		"moco/test/test/20210527-000000/dump.tar",
+		"moco/test/test/20210527-000000/binlog.tar.zst",
+		"moco/test/test/20210528-000000/dump.tar",
+		"moco/test/test/20210528-000000/binlog.tar.zst",
 	}
 
 	testCases := []struct {
@@ -25,7 +29,7 @@ func TestFindNearestDump(t *testing.T) {
 		expectBinlog string
 		expectTime   time.Time
 	}{
-		{"latest", time.Date(2021, time.May, 26, 0, 0, 0, 0, time.UTC),
+		{"exact", time.Date(2021, time.May, 26, 0, 0, 0, 0, time.UTC),
 			"moco/test/test/20210526-000000/dump.tar", "", time.Date(2021, time.May, 26, 0, 0, 0, 0, time.UTC)},
 		{"up-to-date", time.Date(2021, time.May, 26, 1, 0, 0, 0, time.UTC),
 			"moco/test/test/20210526-000000/dump.tar", "", time.Date(2021, time.May, 26, 0, 0, 0, 0, time.UTC)},
@@ -35,6 +39,10 @@ func TestFindNearestDump(t *testing.T) {
 			"moco/test/test/20210525-112233/dump.tar", "moco/test/test/20210525-112233/binlog.tar.zst",
 			time.Date(2021, time.May, 25, 11, 22, 33, 0, time.UTC)},
 		{"not-found", time.Date(2021, time.May, 24, 0, 0, 0, 0, time.UTC), "", "", time.Time{}},
+		{"#563", time.Date(2021, time.May, 27, 12, 0, 0, 0, time.UTC),
+			"moco/test/test/20210527-000000/dump.tar", "moco/test/test/20210527-000000/binlog.tar.zst",
+			time.Date(2021, time.May, 27, 0, 0, 0, 0, time.UTC),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
A bug in RestoreManager.FindNearestDump caused the problem.
Fixes #563.
