### PR TITLE
Add GOMAXPROCS settings for moco-agent and mysqld_exporter

### DIFF
--- a/api/v1beta2/mysqlcluster_types.go
+++ b/api/v1beta2/mysqlcluster_types.go
@@ -435,6 +435,10 @@ type OverwriteContainer struct {
 	// Resources is the container resource to be overwritten.
 	// +optional
 	Resources *ResourceRequirementsApplyConfiguration `json:"resources,omitempty"`
+
+	// GOMAXPROCS overwrites the GOMAXPROCS environment variables.
+	// +optional
+	GOMAXPROCS string `json:"gomaxprocs,omitempty"`
 }
 
 // ResourceRequirementsApplyConfiguration is the type defined to implement the DeepCopy method.

--- a/charts/moco/templates/generated/crds/moco_crds.yaml
+++ b/charts/moco/templates/generated/crds/moco_crds.yaml
@@ -9758,6 +9758,9 @@ spec:
                       items:
                         description: OverwriteContainer defines the container spec used
                         properties:
+                          gomaxprocs:
+                            description: GOMAXPROCS overwrites the GOMAXPROCS environment v
+                            type: string
                           name:
                             description: Name of the container to overwrite.
                             enum:

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -6226,6 +6226,10 @@ spec:
                     items:
                       description: OverwriteContainer defines the container spec used
                       properties:
+                        gomaxprocs:
+                          description: GOMAXPROCS overwrites the GOMAXPROCS environment
+                            v
+                          type: string
                         name:
                           description: Name of the container to overwrite.
                           enum:

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
@@ -6236,6 +6236,10 @@ spec:
                     items:
                       description: OverwriteContainer defines the container spec used
                       properties:
+                        gomaxprocs:
+                          description: GOMAXPROCS overwrites the GOMAXPROCS environment
+                            v
+                          type: string
                         name:
                           description: Name of the container to overwrite.
                           enum:

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -731,6 +731,7 @@ var _ = Describe("MySQLCluster reconciler", func() {
 				foundAgent = true
 				Expect(c.Image).To(Equal(testAgentImage))
 				Expect(c.Args).To(Equal([]string{"--max-delay", "60s"}))
+				Expect(c.Env).To(ContainElements(corev1.EnvVar{Name: constants.GOMAXPROCSEnvKey, Value: constants.GOMAXPROCSDefault}))
 				Expect(c.Resources.Requests).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("100Mi")}))
 				Expect(c.Resources.Limits).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("100Mi")}))
 			case constants.SlowQueryLogAgentContainerName:
@@ -740,6 +741,7 @@ var _ = Describe("MySQLCluster reconciler", func() {
 				Expect(c.Resources.Limits).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("20Mi")}))
 			case constants.ExporterContainerName:
 				foundExporter = true
+				Expect(c.Env).To(ContainElements(corev1.EnvVar{Name: constants.GOMAXPROCSEnvKey, Value: constants.GOMAXPROCSDefault}))
 				Expect(c.Resources.Requests).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m"), corev1.ResourceMemory: resource.MustParse("100Mi")}))
 				Expect(c.Resources.Limits).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m"), corev1.ResourceMemory: resource.MustParse("100Mi")}))
 			}
@@ -848,6 +850,7 @@ var _ = Describe("MySQLCluster reconciler", func() {
 					WithLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}).
 					WithRequests(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
 				),
+				GOMAXPROCS: "2",
 			},
 			{
 				Name: mocov1beta2.ExporterContainerName,
@@ -855,6 +858,7 @@ var _ = Describe("MySQLCluster reconciler", func() {
 					WithLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}).
 					WithRequests(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}),
 				),
+				GOMAXPROCS: "2",
 			},
 			{
 				Name: mocov1beta2.InitContainerName,
@@ -967,12 +971,14 @@ var _ = Describe("MySQLCluster reconciler", func() {
 			case constants.AgentContainerName:
 				Expect(c.Args).To(ContainElement("20s"))
 				Expect(c.Args).To(ContainElement("0 * * * *"))
+				Expect(c.Env).To(ContainElements(corev1.EnvVar{Name: constants.GOMAXPROCSEnvKey, Value: "2"}))
 				Expect(c.Resources.Requests).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}))
 				Expect(c.Resources.Limits).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}))
 			case constants.ExporterContainerName:
 				foundExporter = true
 				Expect(c.Image).To(Equal(testExporterImage))
 				Expect(c.Args).To(HaveLen(3))
+				Expect(c.Env).To(ContainElements(corev1.EnvVar{Name: constants.GOMAXPROCSEnvKey, Value: "2"}))
 				Expect(c.Resources.Requests).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}))
 				Expect(c.Resources.Limits).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}))
 			case "dummy":

--- a/docs/crd_mysqlcluster_v1beta2.md
+++ b/docs/crd_mysqlcluster_v1beta2.md
@@ -123,6 +123,7 @@ OverwriteContainer defines the container spec used for overwriting.
 | ----- | ----------- | ------ | -------- |
 | name | Name of the container to overwrite. | [OverwriteableContainerName](https://pkg.go.dev/github.com/cybozu-go/moco/api/v1beta2#OverwriteableContainerName) | true |
 | resources | Resources is the container resource to be overwritten. | *[ResourceRequirementsApplyConfiguration](https://pkg.go.dev/k8s.io/client-go/applyconfigurations/core/v1#ResourceRequirementsApplyConfiguration) | false |
+| gomaxprocs | GOMAXPROCS overwrites the GOMAXPROCS environment variables. | string | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -45,6 +45,7 @@ const (
 	PodNameEnvKey      = "POD_NAME"
 	PodNamespaceEnvKey = "POD_NAMESPACE"
 	ClusterNameEnvKey  = "CLUSTER_NAME"
+	GOMAXPROCSEnvKey   = "GOMAXPROCS"
 )
 
 // Secret keys to clone data from an external mysqld

--- a/pkg/constants/container.go
+++ b/pkg/constants/container.go
@@ -60,3 +60,6 @@ const (
 
 // PreStop sleep duration
 const PreStopSeconds = "20"
+
+// container default environment variable values
+const GOMAXPROCSDefault = "1"


### PR DESCRIPTION
If GOMAXPROCS is not specified, go program is executed in multi process.
Resource limits is calculated with adding up all processes.
If the total CPU resource usage of the multi process exceeds resource limits, the CPU resource of the process will be limited.
This can causes response latency.

In this PR solves this problem by setting default GOMAXPROCS and providing custom enviornment variables.