### PR TITLE
Revised MySQL Support Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Blog article: [Introducing MOCO, a modern MySQL operator on Kubernetes](https://
 - MySQL: 8.0.18, 8.0.25, 8.0.26, 8.0.27, 8.0.28, 8.0.30, 8.0.31, 8.0.32, 8.0.33, 8.0.34
 - Kubernetes: 1.25, 1.26, 1.27
 
-Other MySQL 8 releases would probably work.  They are simply not tested in our CI.
+MOCO supports (tests) the LTS releases of MySQL 8.
+Innovation releases would probably work. But they are not tested in our CI.
 
 ## Features
 


### PR DESCRIPTION
MOCO supports (tests) the LTS releases of MySQL 8.
We will not test the Innovation releases in our CI.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>