### PR TITLE
api: change the storage version to v1beta2

### DIFF
--- a/api/v1beta1/backuppolicy_types.go
+++ b/api/v1beta1/backuppolicy_types.go
@@ -83,7 +83,6 @@ type BackupPolicySpec struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:storageversion
 
 // BackupPolicy is a namespaced resource that should be referenced from MySQLCluster.
 type BackupPolicy struct {

--- a/api/v1beta1/mysqlcluster_types.go
+++ b/api/v1beta1/mysqlcluster_types.go
@@ -345,7 +345,6 @@ type ReconcileInfo struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status"
 // +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
 // +kubebuilder:printcolumn:name="Primary",type="integer",JSONPath=".status.currentPrimaryIndex"

--- a/api/v1beta2/backuppolicy_types.go
+++ b/api/v1beta2/backuppolicy_types.go
@@ -97,6 +97,7 @@ func (s *BackupPolicySpec) validate() (admission.Warnings, field.ErrorList) {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:storageversion
 
 // BackupPolicy is a namespaced resource that should be referenced from MySQLCluster.
 type BackupPolicy struct {

--- a/api/v1beta2/mysqlcluster_types.go
+++ b/api/v1beta2/mysqlcluster_types.go
@@ -659,6 +659,7 @@ type ReconcileInfo struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status"
 // +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
 // +kubebuilder:printcolumn:name="Primary",type="integer",JSONPath=".status.currentPrimaryIndex"

--- a/charts/moco/templates/generated/crds/moco_crds.yaml
+++ b/charts/moco/templates/generated/crds/moco_crds.yaml
@@ -2030,7 +2030,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: true
+      storage: false
     - name: v1beta2
       schema:
         openAPIV3Schema:
@@ -4043,7 +4043,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: false
+      storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -9671,7 +9671,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -15427,6 +15427,6 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}

--- a/config/crd/bases/moco.cybozu.com_backuppolicies.yaml
+++ b/config/crd/bases/moco.cybozu.com_backuppolicies.yaml
@@ -2183,7 +2183,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
   - name: v1beta2
     schema:
       openAPIV3Schema:
@@ -4353,4 +4353,4 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -6139,7 +6139,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -12435,6 +12435,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_backuppolicies.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_backuppolicies.moco.cybozu.com.yaml
@@ -2182,7 +2182,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
   - name: v1beta2
     schema:
       openAPIV3Schema:
@@ -4352,4 +4352,4 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
@@ -6149,7 +6149,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -12445,6 +12445,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}


### PR DESCRIPTION
We are going to deprecate v1beta1, so need to change the
storage version first.

Part of #545