### PR TITLE
pass password via command arguments on backup

### DIFF
--- a/pkg/bkop/backup.go
+++ b/pkg/bkop/backup.go
@@ -13,7 +13,7 @@ import (
 func (o operator) DumpFull(ctx context.Context, dir string) error {
 	args := []string{
 		fmt.Sprintf("mysql://%s@%s:%d", o.user, o.host, o.port),
-		"--passwords-from-stdin",
+		"-p" + o.password,
 		"--save-passwords=never",
 		"-C", "False",
 		"--",
@@ -25,7 +25,6 @@ func (o operator) DumpFull(ctx context.Context, dir string) error {
 	}
 
 	cmd := exec.CommandContext(ctx, "mysqlsh", args...)
-	cmd.Stdin = strings.NewReader(o.password)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/pkg/bkop/restore.go
+++ b/pkg/bkop/restore.go
@@ -23,7 +23,7 @@ func (o operator) PrepareRestore(ctx context.Context) error {
 func (o operator) LoadDump(ctx context.Context, dir string) error {
 	args := []string{
 		fmt.Sprintf("mysql://%s@%s:%d", o.user, o.host, o.port),
-		"--passwords-from-stdin",
+		"-p" + o.password,
 		"--save-passwords=never",
 		"-C", "False",
 		"--",
@@ -39,7 +39,6 @@ func (o operator) LoadDump(ctx context.Context, dir string) error {
 	}
 
 	cmd := exec.CommandContext(ctx, "mysqlsh", args...)
-	cmd.Stdin = strings.NewReader(o.password)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
If `--passwords-from-stdin` is used, password prompt will be output and it may be handled as a log line without LF. The behavior is problematic because the log line occupies the partial line buffer in logging agent like promtail and will never be flushed naturally.

The command arguments are not visible from outside of the Pod. So this modification is not insecure.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>