### PR TITLE
Sync PVC labels and annotations

### DIFF
--- a/cmd/moco-controller/cmd/root.go
+++ b/cmd/moco-controller/cmd/root.go
@@ -34,6 +34,8 @@ var config struct {
 	backupImage             string
 	fluentBitImage          string
 	exporterImage           string
+	pvcSyncAnnotationKeys   []string
+	pvcSyncLabelKeys        []string
 	interval                time.Duration
 	maxConcurrentReconciles int
 	qps                     int
@@ -103,6 +105,8 @@ func init() {
 	fs.StringVar(&config.backupImage, "backup-image", defaultBackupImage, "The image of moco-backup container")
 	fs.StringVar(&config.fluentBitImage, "fluent-bit-image", moco.FluentBitImage, "The image of fluent-bit sidecar container")
 	fs.StringVar(&config.exporterImage, "mysqld-exporter-image", moco.ExporterImage, "The image of mysqld_exporter sidecar container")
+	fs.StringSliceVar(&config.pvcSyncAnnotationKeys, "pvc-sync-annotation-keys", []string{}, "The keys of annotations from MySQLCluster's volumeClaimTemplates to be synced to the PVC")
+	fs.StringSliceVar(&config.pvcSyncLabelKeys, "pvc-sync-label-keys", []string{}, "The keys of labels from MySQLCluster's volumeClaimTemplates to be synced to the PVC")
 	fs.DurationVar(&config.interval, "check-interval", 1*time.Minute, "Interval of cluster maintenance")
 	fs.IntVar(&config.maxConcurrentReconciles, "max-concurrent-reconciles", 8, "The maximum number of concurrent reconciles which can be run")
 	// The default QPS is 20.

--- a/cmd/moco-controller/cmd/run.go
+++ b/cmd/moco-controller/cmd/run.go
@@ -104,6 +104,8 @@ func subMain(ns, addr string, port int) error {
 		FluentBitImage:          config.fluentBitImage,
 		ExporterImage:           config.exporterImage,
 		SystemNamespace:         ns,
+		PVCSyncAnnotationKeys:   config.pvcSyncAnnotationKeys,
+		PVCSyncLabelKeys:        config.pvcSyncLabelKeys,
 		ClusterManager:          clusterMgr,
 		MaxConcurrentReconciles: config.maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -143,6 +143,8 @@ type MySQLClusterReconciler struct {
 	FluentBitImage          string
 	ExporterImage           string
 	SystemNamespace         string
+	PVCSyncAnnotationKeys   []string
+	PVCSyncLabelKeys        []string
 	ClusterManager          clustering.ClusterManager
 	MaxConcurrentReconciles int
 }

--- a/docs/change-pvc-template.md
+++ b/docs/change-pvc-template.md
@@ -11,10 +11,13 @@ Re-creation StatefulSet is done with the same behavior as `kubectl delete sts mo
 >
 > ref: https://github.com/kubernetes/enhancements/issues/661
 
-When re-creating a StatefulSet, moco-controller does not support any operation other than volume expansion as described below.
-It only re-creates the StatefulSet.
-Therefore, changes to the label and annotation assigned to the PVC must be done by the user.
-This is because there is a concern that if someone other than the moco-controller is editing the PVC's metadata, there may be side effects.
+When re-creating a StatefulSet, moco-controller supports no operation except for volume expansion as described below.
+It simply re-creates the StatefulSet.
+However, if the labels and annotations on the PVC and the `.spec.volumeClaimTemplates` in the MySQLCluster have identical keys,
+the labels and annotations on the PVC are updated with the values from the `.spec.volumeClaimTemplates`.
+
+For all other labels and annotations, given the potential side effects, such updates must be performed by the user themselves.
+This guideline is essential to prevent potential side-effects if entities other than the moco-controller are manipulating the PVC's metadata.
 
 ### Metrics
 


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/558

https://github.com/cybozu-go/moco/issues/558#issuecomment-1690940455

Update the value if the label and annotation of the PVC is identical to the label and annotation key of the volumeClaimTemplate based on the above comment specification.