### PR TITLE
Convert e2e to workflow_dispatch

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -7,11 +7,7 @@ on:
     paths-ignore:
       - '**.md'
       - "containers/**"
-  pull_request:
-    types: [opened, synchronize]
-    paths-ignore:
-      - '**.md'
-      - "containers/**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,17 +22,48 @@ env:
 #
 # NOTE: Current Cybozu internal use version is 8.0.28.
 jobs:
+  commit-status-start:
+    name: Commit status start
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set pending to commit status
+        uses: myrotvorets/set-commit-status-action@38f3f27c7d52fb381273e95542f07f0fba301307 # v2.0.0
+        with:
+          sha: ${{ github.sha }}
+  extract-github-ref:
+    name: extract github.ref
+    runs-on: ubuntu-22.04
+    outputs:
+      github_ref: ${{ steps.extract.outputs.github_ref }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract github.ref
+        id: extract
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # if exists PR refs/pull/<pull_request_number>/merge
+          # if not exists PR → github.ref
+          PR_number=$(gh pr view --json number -q .number)
+          if [ $? == 0 ];then
+            echo "github_ref=refs/pull/${PR_number}/merge" >> $GITHUB_OUTPUT
+          else
+            echo "github_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          fi
   dbtest:
     name: Integration tests with MySQL
+    needs: extract-github-ref
     strategy:
       matrix:
         mysql-version: ["8.0.28", "8.0.34", "8.0.35"]
     uses: ./.github/workflows/dbtest.yaml
     with:
       mysql-version: ${{ matrix.mysql-version }}
+      ref: ${{ needs.extract-github-ref.outputs.github_ref }}
 
   e2e:
     name: Supported Kubernetes versions End-to-End Tests
+    needs: extract-github-ref
     strategy:
       matrix:
         mysql-version: ["8.0.35"]
@@ -45,9 +72,11 @@ jobs:
     with:
       k8s-version: ${{ matrix.k8s-version }}
       mysql-version: ${{ matrix.mysql-version }}
+      ref: ${{ needs.extract-github-ref.outputs.github_ref }}
 
   e2e-mysql:
     name: Supported MySQL versions End-to-End Tests
+    needs: extract-github-ref
     strategy:
       matrix:
         mysql-version: ["8.0.28", "8.0.34", "8.0.35"]
@@ -56,13 +85,17 @@ jobs:
     with:
       k8s-version: ${{ matrix.k8s-version }}
       mysql-version: ${{ matrix.mysql-version }}
+      ref: ${{ needs.extract-github-ref.outputs.github_ref }}
 
   upgrade:
     name: Upgrade Test
+    needs: extract-github-ref
     runs-on:
       group: moco
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.extract-github-ref.outputs.github_ref }}
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -84,3 +117,26 @@ jobs:
         with:
           name: logs-upgrade.tar.gz
           path: e2e/logs.tar.gz
+  commit-status-final:
+    if: always()
+    name: Commit Status Final
+    needs:
+      - dbtest
+      - e2e
+      - e2e-mysql
+      - upgrade
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get final status
+        id: final-status
+        run: |
+          if "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}"; then
+            echo "result=failure" >> $GITHUB_OUTPUT
+          else
+            echo "result=success" >> $GITHUB_OUTPUT
+          fi
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@38f3f27c7d52fb381273e95542f07f0fba301307 # v2.0.0
+        with:
+          sha: ${{ github.sha }}
+          status: ${{ steps.final-status.outputs.result }}

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -27,9 +27,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Set pending to commit status
-        uses: myrotvorets/set-commit-status-action@38f3f27c7d52fb381273e95542f07f0fba301307 # v2.0.0
-        with:
-          sha: ${{ github.sha }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            -f state='pending' \
+            -f target_url='${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+            -f context='${{ github.workflow }}'
   extract-github-ref:
     name: extract github.ref
     runs-on: ubuntu-22.04
@@ -136,7 +144,14 @@ jobs:
             echo "result=success" >> $GITHUB_OUTPUT
           fi
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@38f3f27c7d52fb381273e95542f07f0fba301307 # v2.0.0
-        with:
-          sha: ${{ github.sha }}
-          status: ${{ steps.final-status.outputs.result }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            -f state='${{ steps.final-status.outputs.result }}' \
+            -f target_url='${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+            -f context='${{ github.workflow }}'

--- a/.github/workflows/dbtest.yaml
+++ b/.github/workflows/dbtest.yaml
@@ -6,12 +6,18 @@ on:
       mysql-version:
         required: true
         type: string
+      ref:
+        required: false
+        type: string
+        default: ${{ github.ref }}
 
 jobs:
   dbtest:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,6 +9,10 @@ on:
       k8s-version:
         required: true
         type: string
+      ref:
+        required: false
+        type: string
+        default: ${{ github.ref }}
 
 jobs:
   e2e:
@@ -16,6 +20,8 @@ jobs:
       group: moco
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod

--- a/.github/workflows/handle-pr-comments.yaml
+++ b/.github/workflows/handle-pr-comments.yaml
@@ -1,0 +1,37 @@
+name: handle PR comments
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: write
+
+jobs:
+  trigger_e2e:
+    name: "Trigger e2e test"
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/test') && contains('["OWNER", "COLLABORATOR", "CONTRIBUTOR"]', github.event.comment.author_association)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: create reaction
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # https://docs.github.com/ja/rest/reactions/reactions?apiVersion=2022-11-28#create-reaction-for-an-issue-comment
+          # needs pull_requests:write permission
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content='rocket'
+      - uses: actions/checkout@v4
+      - name: trigger e2e
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH_NAME=$(gh pr view --json headRefName --jq .headRefName ${{ github.event.issue.number }})
+          echo "triggering e2e"
+          gh workflow run --ref ${BRANCH_NAME} ci-e2e.yaml

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -30,6 +30,8 @@ MOCO supports multiple MySQL versions.
 The three MySQL versions always used by CI are Cybozu internal use version, the latest, and one version before the latest.
 Other supported MySQL versions will be [tested only in Weekly](.github/workflows/weekly.yaml).
 
+To run an e2e test for a PR, comment the PR with `/test`. This is only valid for comments from accounts with "OWNER", "COLLABORATOR" or "CONTRIBUTOR" privileges.
+
 ## Generated files
 
 Some files in the repository are auto-generated.


### PR DESCRIPTION
- "OWNER", "COLLABORATOR", and "CONTRIBUTOR" comment `/test` in the PR, the e2e test is executed.
- In converting `ci-e2e` to `workflow_dispatch`, status checks are now updated manually in workflow.
  - ~using `myrotvorets/set-commit-status-action`~
- Added process to ci-e2e to retrieve branches to be tested.
  - With `on.pull_request`, the post-merge branch was used for testing without the trigger being aware of it, but with `on.workflow_dispath`, the `github.ref` is the branch that was executed and the post-merge branch is not used.

- The `.on.issue_comment` workflow is not executed until merged into the main branch, so commenting `/test` on this PR will not execute the e2e test.

Signed-off-by: kouki <kouworld0123@gmail.com>