### PR TITLE
Fix ci-e2e on main branch

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -50,6 +50,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set +e
           # if exists PR refs/pull/<pull_request_number>/merge
           # if not exists PR → github.ref
           PR_number=$(gh pr view --json number -q .number)

--- a/.github/workflows/handle-pr-comments.yaml
+++ b/.github/workflows/handle-pr-comments.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   trigger_e2e:
     name: "Trigger e2e test"
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/test') && contains('["OWNER", "COLLABORATOR", "CONTRIBUTOR"]', github.event.comment.author_association)
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/test') && contains('["OWNER", "COLLABORATOR", "MEMBER"]', github.event.comment.author_association)
     runs-on: ubuntu-22.04
     steps:
       - name: create reaction


### PR DESCRIPTION
I thought `gh pr view --json number -q .number` was failing in the main branch,
but the whole test was failing, so I fixed it.

Change the authority to skip the comment `/test`.
https://docs.github.com/en/graphql/reference/enums#commentauthorassociation

Signed-off-by: kouki <kouworld0123@gmail.com>