### PR TITLE
 Option to to use localhost instead of pod name

### DIFF
--- a/api/v1beta2/mysqlcluster_types.go
+++ b/api/v1beta2/mysqlcluster_types.go
@@ -117,6 +117,11 @@ type MySQLClusterSpec struct {
 	// If set to true, the sidecar container is not added. The default is false.
 	// +optional
 	DisableSlowQueryLogContainer bool `json:"disableSlowQueryLogContainer,omitempty"`
+
+	// MySQLDLocalHost configures mysqld interface to bind and be accessed over localhost instead of pod name.
+	// During container init moco-agent will set mysql admin interface is bound to localhost. The moco-agent will also
+	// communicate with mysqld over localhost when acting as a sidecar.
+	MySQLDLocalHost bool `json:"mysqldLocalHost,omitempty"`
 }
 
 func (s MySQLClusterSpec) validateCreate() (admission.Warnings, field.ErrorList) {

--- a/api/v1beta2/mysqlcluster_types.go
+++ b/api/v1beta2/mysqlcluster_types.go
@@ -118,10 +118,10 @@ type MySQLClusterSpec struct {
 	// +optional
 	DisableSlowQueryLogContainer bool `json:"disableSlowQueryLogContainer,omitempty"`
 
-	// MySQLDLocalHost configures mysqld interface to bind and be accessed over localhost instead of pod name.
+	// AgentUseLocalhost configures the mysqld interface to bind and be accessed over localhost instead of pod name.
 	// During container init moco-agent will set mysql admin interface is bound to localhost. The moco-agent will also
 	// communicate with mysqld over localhost when acting as a sidecar.
-	MySQLDLocalHost bool `json:"mysqldLocalHost,omitempty"`
+	AgentUseLocalhost bool `json:"agentUseLocalhost,omitempty"`
 }
 
 func (s MySQLClusterSpec) validateCreate() (admission.Warnings, field.ErrorList) {

--- a/charts/moco/templates/generated/crds/moco_crds.yaml
+++ b/charts/moco/templates/generated/crds/moco_crds.yaml
@@ -2144,13 +2144,13 @@ spec:
                   description: 'MaxDelaySeconds configures the readiness probe of '
                   minimum: 0
                   type: integer
-                mysqldLocalHost:
-                  description: MySQLDLocalHost configures mysqld interface to bin
-                  type: boolean
                 mysqlConfigMapName:
                   description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                   nullable: true
                   type: string
+                mysqldLocalHost:
+                  description: MySQLDLocalHost configures mysqld interface to bin
+                  type: boolean
                 podTemplate:
                   description: PodTemplate is a `Pod` template for MySQL server c
                   properties:

--- a/charts/moco/templates/generated/crds/moco_crds.yaml
+++ b/charts/moco/templates/generated/crds/moco_crds.yaml
@@ -2124,6 +2124,9 @@ spec:
             spec:
               description: MySQLClusterSpec defines the desired state of MySQ
               properties:
+                agentUseLocalhost:
+                  description: 'AgentUseLocalhost configures the mysqld interface '
+                  type: boolean
                 backupPolicyName:
                   description: The name of BackupPolicy custom resource in the sa
                   nullable: true
@@ -2148,9 +2151,6 @@ spec:
                   description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                   nullable: true
                   type: string
-                agentUseLocalhost:
-                  description: AgentUseLocalhost configures mysqld interface to bin
-                  type: boolean
                 podTemplate:
                   description: PodTemplate is a `Pod` template for MySQL server c
                   properties:

--- a/charts/moco/templates/generated/crds/moco_crds.yaml
+++ b/charts/moco/templates/generated/crds/moco_crds.yaml
@@ -2144,6 +2144,9 @@ spec:
                   description: 'MaxDelaySeconds configures the readiness probe of '
                   minimum: 0
                   type: integer
+                mysqldLocalHost:
+                  description: MySQLDLocalHost configures mysqld interface to bin
+                  type: boolean
                 mysqlConfigMapName:
                   description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                   nullable: true

--- a/charts/moco/templates/generated/crds/moco_crds.yaml
+++ b/charts/moco/templates/generated/crds/moco_crds.yaml
@@ -2148,8 +2148,8 @@ spec:
                   description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                   nullable: true
                   type: string
-                mysqldLocalHost:
-                  description: MySQLDLocalHost configures mysqld interface to bin
+                agentUseLocalhost:
+                  description: AgentUseLocalhost configures mysqld interface to bin
                   type: boolean
                 podTemplate:
                   description: PodTemplate is a `Pod` template for MySQL server c

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -55,6 +55,9 @@ spec:
           spec:
             description: MySQLClusterSpec defines the desired state of MySQ
             properties:
+              agentUseLocalhost:
+                description: 'AgentUseLocalhost configures the mysqld interface '
+                type: boolean
               backupPolicyName:
                 description: The name of BackupPolicy custom resource in the sa
                 nullable: true
@@ -79,9 +82,6 @@ spec:
                 description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                 nullable: true
                 type: string
-              agentUseLocalhost:
-                description: AgentUseLocalhost configures mysqld interface to bin
-                type: boolean
               podTemplate:
                 description: PodTemplate is a `Pod` template for MySQL server c
                 properties:

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -75,6 +75,9 @@ spec:
                 description: 'MaxDelaySeconds configures the readiness probe of '
                 minimum: 0
                 type: integer
+              mysqldLocalHost:
+                description: MySQLDLocalHost configures mysqld interface to bin
+                type: boolean
               mysqlConfigMapName:
                 description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                 nullable: true

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -79,8 +79,8 @@ spec:
                 description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                 nullable: true
                 type: string
-              mysqldLocalHost:
-                description: MySQLDLocalHost configures mysqld interface to bin
+              agentUseLocalhost:
+                description: AgentUseLocalhost configures mysqld interface to bin
                 type: boolean
               podTemplate:
                 description: PodTemplate is a `Pod` template for MySQL server c

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -75,13 +75,13 @@ spec:
                 description: 'MaxDelaySeconds configures the readiness probe of '
                 minimum: 0
                 type: integer
-              mysqldLocalHost:
-                description: MySQLDLocalHost configures mysqld interface to bin
-                type: boolean
               mysqlConfigMapName:
                 description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                 nullable: true
                 type: string
+              mysqldLocalHost:
+                description: MySQLDLocalHost configures mysqld interface to bin
+                type: boolean
               podTemplate:
                 description: PodTemplate is a `Pod` template for MySQL server c
                 properties:

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
@@ -55,6 +55,9 @@ spec:
           spec:
             description: MySQLClusterSpec defines the desired state of MySQ
             properties:
+              agentUseLocalhost:
+                description: 'AgentUseLocalhost configures the mysqld interface '
+                type: boolean
               backupPolicyName:
                 description: The name of BackupPolicy custom resource in the sa
                 nullable: true
@@ -79,9 +82,6 @@ spec:
                 description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                 nullable: true
                 type: string
-              agentUseLocalhost:
-                description: AgentUseLocalhost configures mysqld interface to bin
-                type: boolean
               podTemplate:
                 description: PodTemplate is a `Pod` template for MySQL server c
                 properties:

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
@@ -75,6 +75,9 @@ spec:
                 description: 'MaxDelaySeconds configures the readiness probe of '
                 minimum: 0
                 type: integer
+              mysqldLocalHost:
+                description: MySQLDLocalHost configures mysqld interface to bin
+                type: boolean
               mysqlConfigMapName:
                 description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                 nullable: true

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
@@ -79,8 +79,8 @@ spec:
                 description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                 nullable: true
                 type: string
-              mysqldLocalHost:
-                description: MySQLDLocalHost configures mysqld interface to bin
+              agentUseLocalhost:
+                description: AgentUseLocalhost configures mysqld interface to bin
                 type: boolean
               podTemplate:
                 description: PodTemplate is a `Pod` template for MySQL server c

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
@@ -75,13 +75,13 @@ spec:
                 description: 'MaxDelaySeconds configures the readiness probe of '
                 minimum: 0
                 type: integer
-              mysqldLocalHost:
-                description: MySQLDLocalHost configures mysqld interface to bin
-                type: boolean
               mysqlConfigMapName:
                 description: 'MySQLConfigMapName is a `ConfigMap` name of MySQL '
                 nullable: true
                 type: string
+              mysqldLocalHost:
+                description: MySQLDLocalHost configures mysqld interface to bin
+                type: boolean
               podTemplate:
                 description: PodTemplate is a `Pod` template for MySQL server c
                 properties:

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -134,6 +134,8 @@ func (r *MySQLClusterReconciler) makeV1AgentContainer(cluster *mocov1beta2.MySQL
 		c.WithArgs(fmt.Sprintf("--log-rotation-schedule=%s", cluster.Spec.LogRotationSchedule))
 	}
 
+	c.WithArgs(fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.MySQLDLocalHost))
+
 	c.WithVolumeMounts(
 		corev1ac.VolumeMount().
 			WithName(constants.RunVolumeName).
@@ -327,6 +329,7 @@ func (r *MySQLClusterReconciler) makeMocoInitContainer(ctx context.Context, clus
 			filepath.Join(constants.SharedPath, constants.InitCommand),
 			fmt.Sprintf("%s=%s", constants.MocoInitDataDirFlag, constants.MySQLDataPath),
 			fmt.Sprintf("%s=%s", constants.MocoInitConfDirFlag, constants.MySQLInitConfPath),
+			fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.MySQLDLocalHost),
 			fmt.Sprintf("%d", cluster.Spec.ServerIDBase),
 		).WithEnv(
 		corev1ac.EnvVar().

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -134,7 +134,9 @@ func (r *MySQLClusterReconciler) makeV1AgentContainer(cluster *mocov1beta2.MySQL
 		c.WithArgs(fmt.Sprintf("--log-rotation-schedule=%s", cluster.Spec.LogRotationSchedule))
 	}
 
-	c.WithArgs(fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.MySQLDLocalHost))
+	if cluster.Spec.MySQLDLocalHost {
+		c.WithArgs(fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.MySQLDLocalHost))
+	}
 
 	c.WithVolumeMounts(
 		corev1ac.VolumeMount().
@@ -322,24 +324,30 @@ func (r *MySQLClusterReconciler) makeV1InitContainer(ctx context.Context, cluste
 }
 
 func (r *MySQLClusterReconciler) makeMocoInitContainer(ctx context.Context, cluster *mocov1beta2.MySQLCluster, image string) (*corev1ac.ContainerApplyConfiguration, error) {
+	cmd := []string{
+		filepath.Join(constants.SharedPath, constants.InitCommand),
+		fmt.Sprintf("%s=%s", constants.MocoInitDataDirFlag, constants.MySQLDataPath),
+		fmt.Sprintf("%s=%s", constants.MocoInitConfDirFlag, constants.MySQLInitConfPath),
+		fmt.Sprintf("%d", cluster.Spec.ServerIDBase),
+	}
+
+	if cluster.Spec.MySQLDLocalHost {
+		cmd = append(cmd, fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.MySQLDLocalHost))
+	}
+
 	c := corev1ac.Container().
 		WithName(constants.InitContainerName).
 		WithImage(image).
-		WithCommand(
-			filepath.Join(constants.SharedPath, constants.InitCommand),
-			fmt.Sprintf("%s=%s", constants.MocoInitDataDirFlag, constants.MySQLDataPath),
-			fmt.Sprintf("%s=%s", constants.MocoInitConfDirFlag, constants.MySQLInitConfPath),
-			fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.MySQLDLocalHost),
-			fmt.Sprintf("%d", cluster.Spec.ServerIDBase),
-		).WithEnv(
-		corev1ac.EnvVar().
-			WithName(constants.PodNameEnvKey).
-			WithValueFrom(corev1ac.EnvVarSource().
-				WithFieldRef(corev1ac.ObjectFieldSelector().
-					WithAPIVersion("v1").
-					WithFieldPath("metadata.name")),
-			),
-	).WithVolumeMounts(
+		WithCommand(cmd...).
+		WithEnv(
+			corev1ac.EnvVar().
+				WithName(constants.PodNameEnvKey).
+				WithValueFrom(corev1ac.EnvVarSource().
+					WithFieldRef(corev1ac.ObjectFieldSelector().
+						WithAPIVersion("v1").
+						WithFieldPath("metadata.name")),
+				),
+		).WithVolumeMounts(
 		corev1ac.VolumeMount().
 			WithName(constants.MySQLDataVolumeName).
 			WithMountPath(constants.MySQLDataPath),

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	mocov1beta2 "github.com/cybozu-go/moco/api/v1beta2"
 	"github.com/cybozu-go/moco/pkg/constants"
@@ -128,14 +129,14 @@ func (r *MySQLClusterReconciler) makeV1AgentContainer(cluster *mocov1beta2.MySQL
 		WithImage(r.AgentImage)
 
 	if cluster.Spec.MaxDelaySeconds != nil {
-		c.WithArgs(fmt.Sprintf("--max-delay=%ds", *cluster.Spec.MaxDelaySeconds))
+		c.WithArgs("--max-delay", fmt.Sprintf("%ds", *cluster.Spec.MaxDelaySeconds))
 	}
 	if cluster.Spec.LogRotationSchedule != "" {
-		c.WithArgs(fmt.Sprintf("--log-rotation-schedule=%s", cluster.Spec.LogRotationSchedule))
+		c.WithArgs("--log-rotation-schedule", cluster.Spec.LogRotationSchedule)
 	}
 
 	if cluster.Spec.AgentUseLocalhost {
-		c.WithArgs(fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.AgentUseLocalhost))
+		c.WithArgs(constants.MocoMySQLDLocalhostFlag, strconv.FormatBool(cluster.Spec.AgentUseLocalhost))
 	}
 
 	c.WithVolumeMounts(

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -128,10 +128,10 @@ func (r *MySQLClusterReconciler) makeV1AgentContainer(cluster *mocov1beta2.MySQL
 		WithImage(r.AgentImage)
 
 	if cluster.Spec.MaxDelaySeconds != nil {
-		c.WithArgs("--max-delay", fmt.Sprintf("%ds", *cluster.Spec.MaxDelaySeconds))
+		c.WithArgs(fmt.Sprintf("--max-delay=%ds", *cluster.Spec.MaxDelaySeconds))
 	}
 	if cluster.Spec.LogRotationSchedule != "" {
-		c.WithArgs("--log-rotation-schedule", cluster.Spec.LogRotationSchedule)
+		c.WithArgs(fmt.Sprintf("--log-rotation-schedule=%s", cluster.Spec.LogRotationSchedule))
 	}
 
 	c.WithVolumeMounts(

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -134,8 +134,8 @@ func (r *MySQLClusterReconciler) makeV1AgentContainer(cluster *mocov1beta2.MySQL
 		c.WithArgs(fmt.Sprintf("--log-rotation-schedule=%s", cluster.Spec.LogRotationSchedule))
 	}
 
-	if cluster.Spec.MySQLDLocalHost {
-		c.WithArgs(fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.MySQLDLocalHost))
+	if cluster.Spec.AgentUseLocalhost {
+		c.WithArgs(fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.AgentUseLocalhost))
 	}
 
 	c.WithVolumeMounts(
@@ -331,8 +331,8 @@ func (r *MySQLClusterReconciler) makeMocoInitContainer(ctx context.Context, clus
 		fmt.Sprintf("%d", cluster.Spec.ServerIDBase),
 	}
 
-	if cluster.Spec.MySQLDLocalHost {
-		cmd = append(cmd, fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.MySQLDLocalHost))
+	if cluster.Spec.AgentUseLocalhost {
+		cmd = append(cmd, fmt.Sprintf("%s=%t", constants.MocoMySQLDLocalhostFlag, cluster.Spec.AgentUseLocalhost))
 	}
 
 	c := corev1ac.Container().

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -840,6 +840,7 @@ var _ = Describe("MySQLCluster reconciler", func() {
 		cluster.Spec.MaxDelaySeconds = ptr.To[int](20)
 		cluster.Spec.StartupWaitSeconds = 3
 		cluster.Spec.LogRotationSchedule = "0 * * * *"
+		cluster.Spec.AgentUseLocalhost = true
 		cluster.Spec.DisableSlowQueryLogContainer = true
 		cluster.Spec.PodTemplate.OverwriteContainers = []mocov1beta2.OverwriteContainer{
 			{
@@ -967,6 +968,7 @@ var _ = Describe("MySQLCluster reconciler", func() {
 			case constants.AgentContainerName:
 				Expect(c.Args).To(ContainElement("20s"))
 				Expect(c.Args).To(ContainElement("0 * * * *"))
+				Expect(c.Args).To(ContainElements("--mysqld-localhost", "true"))
 				Expect(c.Resources.Requests).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}))
 				Expect(c.Resources.Limits).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}))
 			case constants.ExporterContainerName:

--- a/docs/crd_mysqlcluster_v1beta2.md
+++ b/docs/crd_mysqlcluster_v1beta2.md
@@ -83,6 +83,7 @@ MySQLClusterSpec defines the desired state of MySQLCluster
 | backupPolicyName | The name of BackupPolicy custom resource in the same namespace. If this is set, MOCO creates a CronJob to take backup of this MySQL cluster periodically. | *string | false |
 | restore | Restore is the specification to perform Point-in-Time-Recovery from existing cluster. If this field is not null, MOCO restores the data as specified and create a new cluster with the data.  This field is not editable. | *[RestoreSpec](#restorespec) | false |
 | disableSlowQueryLogContainer | DisableSlowQueryLogContainer controls whether to add a sidecar container named \"slow-log\" to output slow logs as the containers output. If set to true, the sidecar container is not added. The default is false. | bool | false |
+| mysqldLocalHost | MySQLDLocalHost configures mysqld interface to bind and be accessed over localhost instead of pod name. During container init moco-agent will set mysql admin interface is bound to localhost. The moco-agent will also communicate with mysqld over localhost when acting as a sidecar. | bool | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/docs/crd_mysqlcluster_v1beta2.md
+++ b/docs/crd_mysqlcluster_v1beta2.md
@@ -83,7 +83,7 @@ MySQLClusterSpec defines the desired state of MySQLCluster
 | backupPolicyName | The name of BackupPolicy custom resource in the same namespace. If this is set, MOCO creates a CronJob to take backup of this MySQL cluster periodically. | *string | false |
 | restore | Restore is the specification to perform Point-in-Time-Recovery from existing cluster. If this field is not null, MOCO restores the data as specified and create a new cluster with the data.  This field is not editable. | *[RestoreSpec](#restorespec) | false |
 | disableSlowQueryLogContainer | DisableSlowQueryLogContainer controls whether to add a sidecar container named \"slow-log\" to output slow logs as the containers output. If set to true, the sidecar container is not added. The default is false. | bool | false |
-| mysqldLocalHost | MySQLDLocalHost configures mysqld interface to bind and be accessed over localhost instead of pod name. During container init moco-agent will set mysql admin interface is bound to localhost. The moco-agent will also communicate with mysqld over localhost when acting as a sidecar. | bool | false |
+| agentUseLocalhost | AgentUseLocalhost configures the mysqld interface to bind and be accessed over localhost instead of pod name. During container init moco-agent will set mysql admin interface is bound to localhost. The moco-agent will also communicate with mysqld over localhost when acting as a sidecar. | bool | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -65,6 +65,8 @@ const (
 	MocoInitDataDirFlag = "--data-dir"
 	// MocoInitConfDirFlag is flag for conf dir.
 	MocoInitConfDirFlag = "--conf-dir"
+	// MocoMySQLDLocalhostFlag is flag for localhost bind.
+	MocoMySQLDLocalhostFlag = "--mysqld-localhost"
 )
 
 const LowerCaseTableNamesConfKey = "lower_case_table_names"


### PR DESCRIPTION
When running with istio enabled the communication between the agent and mysqld fails. To overcome this the admin interface for mysqld should be bound to `localhost` and the agent should communicate on `localhost` as well, rather than using pod name.

[More context here](https://github.com/cybozu-go/moco/pull/658#issuecomment-2012142633)

Corresponding moco-agent PR here: https://github.com/cybozu-go/moco-agent/pull/92

I also noticed that `max-delay` and `log-rotation-schedule` are being split across multiple lines when passed to the agent sidecar, which seemes unintentional.