### PR TITLE
Build and release Moco controller/backup images for arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v3
@@ -37,7 +37,7 @@ jobs:
       with:
         builder: ${{ steps.buildx.outputs.name }}
         push: true
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         target: controller
         labels: ${{ steps.meta.outputs.labels }}
@@ -51,7 +51,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v3
@@ -76,7 +76,7 @@ jobs:
       with:
         builder: ${{ steps.buildx.outputs.name }}
         push: true
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha


### PR DESCRIPTION
Related issue #490

Enables linux/arm64 build platform back for controller/backup images and installs the MySQL Shell from tar archive (which **is** available also for ARM), instead of Ubuntu package (which is available **only** for x86-64). I did basic testing of controller/backup and all looked working on both platforms.