### PR TITLE
Helm chart CRDs optional and not deleted on uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,10 @@ manifests: controller-gen kustomize yq ## Generate WebhookConfiguration, Cluster
 	mkdir -p charts/moco/templates/generated/crds/
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	$(KUSTOMIZE) build config/crd -o config/crd/tests # Outputs static CRDs for use with Envtest.
-	$(KUSTOMIZE) build config/kustomize-to-helm/overlays/crds | $(YQ) e "." - > charts/moco/templates/generated/crds/moco_crds.yaml
 	$(KUSTOMIZE) build config/kustomize-to-helm/overlays/templates | $(YQ) e "." - > charts/moco/templates/generated/generated.yaml
+	echo '{{- if .Values.crds.enabled }}' > charts/moco/templates/generated/crds/moco_crds.yaml
+	$(KUSTOMIZE) build config/kustomize-to-helm/overlays/crds | $(YQ) e "." - >> charts/moco/templates/generated/crds/moco_crds.yaml
+	echo '{{- end }}' >> charts/moco/templates/generated/crds/moco_crds.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/charts/moco/templates/generated/crds/moco_crds.yaml
+++ b/charts/moco/templates/generated/crds/moco_crds.yaml
@@ -1,8 +1,10 @@
+{{- if .Values.crds.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "moco.name" . }}'
@@ -2058,6 +2060,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/moco-serving-cert'
     controller-gen.kubebuilder.io/version: v0.13.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "moco.name" . }}'
@@ -7873,3 +7876,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/charts/moco/values.yaml
+++ b/charts/moco/values.yaml
@@ -12,6 +12,10 @@ resources:
     cpu: 100m
     memory: 20Mi
 
+crds:
+  # crds.enabled -- Install and update CRDs as part of the Helm chart.
+  enabled: true
+
 # extraArgs -- Additional command line flags to pass to moco-controller binary.
 extraArgs: []
 

--- a/config/kustomize-to-helm/overlays/crds/kustomization.yaml
+++ b/config/kustomize-to-helm/overlays/crds/kustomization.yaml
@@ -7,5 +7,8 @@ patchesStrategicMerge:
 commonLabels:
   app.kubernetes.io/name: moco
 
+commonAnnotations:
+  helm.sh/resource-policy: keep
+
 transformers:
   - label-transformer.yaml


### PR DESCRIPTION
I was trying to deal with #682 to move CRDs from `templates/generated/crds/` to `crds/`, but I found out that one CRD has configured conversion webhook and certificate, which are deployment/environment specific:
https://github.com/cybozu-go/moco/blob/a683b05a3cc2692114743f4c3f71ab660d22109c/charts/moco/templates/generated/crds/moco_crds.yaml#L2073-L2074 Hmm... So I came with a different approach, which is used also in some other projects: leave it part of templates, but make it conditional and prevent Helm to remove it.

Similar approach can be seen in cert-manager or Rook, e.g.:
- https://github.com/rook/rook/blob/master/deploy/charts/rook-ceph/templates/resources.yaml#L1
- https://github.com/rook/rook/blob/master/deploy/charts/rook-ceph/templates/resources.yaml#L8

Changes:
- new crds.enabled Helm variable to create CRDs conditionally
- label CRDs with `helm.sh/resource-policy: keep` to avoid their delete on uninstall