### PR TITLE
Add caution for updating chart to v0.11.x

### DIFF
--- a/charts/moco/CHANGELOG.md
+++ b/charts/moco/CHANGELOG.md
@@ -5,6 +5,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Caution
+This release introduces the `crds.enabled` parameter to the Helm Chart.
+
+When updating to a new chart from chart v0.10.x or lower, you **MUST** leave this parameter `true` (the default value).
+If you turn off this option when updating, the CRD will be removed, causing data loss.
+
+### Changed
+- chart: add value to set a PriorityClass [#661](https://github.com/cybozu-go/moco/pull/661)
+- Helm chart CRDs optional and not deleted on uninstall [#684](https://github.com/cybozu-go/moco/pull/684), [685](https://github.com/cybozu-go/moco/pull/685)
+
+### Contributors
+- @fgeorgeanybox
+- @vholer
+
 ## [0.10.2] - 2024-03-08
 ### Changed
 - Bump appVersion to 0.20.2 [#650](https://github.com/cybozu-go/moco/pull/650)

--- a/charts/moco/README.md
+++ b/charts/moco/README.md
@@ -39,10 +39,11 @@ $ helm install --create-namespace --namespace moco-system moco -f values.yaml mo
 ## Values
 
 | Key                       | Type   | Default                                       | Description                                                      |
-|---------------------------|--------|-----------------------------------------------|------------------------------------------------------------------|
+| ------------------------- | ------ | --------------------------------------------- | ---------------------------------------------------------------- |
 | image.repository          | string | `"ghcr.io/cybozu-go/moco"`                    | MOCO image repository to use.                                    |
 | image.tag                 | string | `{{ .Chart.AppVersion }}`                     | MOCO image tag to use.                                           |
 | resources                 | object | `{"requests":{"cpu":"100m","memory":"20Mi"}}` | resources used by moco-controller.                               |
+| crds.enabled              | bool   | `true`                                        | Install and update CRDs as part of the Helm chart.               |
 | extraArgs                 | list   | `[]`                                          | Additional command line flags to pass to moco-controller binary. |
 | nodeSelector              | object | `{}`                                          | nodeSelector used by moco-controller.                            |
 | affinity                  | object | `{}`                                          | affinity used by moco-controller.                                |
@@ -58,12 +59,23 @@ You can use the `helm template` command to render manifests.
 $ helm template --namespace moco-system moco moco/moco
 ```
 
-## Upgrade CRDs
+## CRD considerations
 
-There is no support at this time for upgrading or deleting CRDs using Helm.
-Users must manually upgrade the CRD if there is a change in the CRD used by MOCO.
+### Installing or updating CRDs
 
-https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#install-a-crd-declaration-before-using-the-resource
+MOCO Helm Chart installs or updates CRDs by default. If you want to manage CRDs on your own, turn off the `crds.enabled` parameter.
+
+### Removing CRDs
+
+Helm does not remove the CRDs due to the [`helm.sh/resource-policy: keep` annotation](https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource).
+When uninstalling, please remove the CRDs manually.
+
+## Migrate to v0.11.0 or higher
+
+Chart version v0.11.0 introduces the `crds.enabled` parameter.
+
+When updating to a new chart from chart v0.10.x or lower, you **MUST** leave this parameter `true` (the default value).
+If you turn off this option when updating, the CRD will be removed, causing data loss.
 
 ## Migrate to v0.3.0
 


### PR DESCRIPTION
part of https://github.com/cybozu-go/moco/issues/682

This PR adds a caution for updating the chart.
When user updates MOCO Chart from chart v0.10.x or lower with `--set crds.enabled=false`, CRDs will be removed.

1. Install chart v0.10.2
```console
$ git checkout chart-v0.10.2
$ helm install --create-namespace --namespace moco-system moco charts/moco/
NAME: moco
LAST DEPLOYED: Tue Jun  4 16:39:42 2024
NAMESPACE: moco-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
$ kubectl get crd
NAME                                  CREATED AT
backuppolicies.moco.cybozu.com        2024-06-04T07:39:43Z
certificaterequests.cert-manager.io   2024-06-04T07:37:31Z
certificates.cert-manager.io          2024-06-04T07:37:31Z
challenges.acme.cert-manager.io       2024-06-04T07:37:32Z
clusterissuers.cert-manager.io        2024-06-04T07:37:32Z
issuers.cert-manager.io               2024-06-04T07:37:32Z
mysqlclusters.moco.cybozu.com         2024-06-04T07:39:43Z
orders.acme.cert-manager.io           2024-06-04T07:37:32Z
```

2. Update to the latest chart with `--set crds.enabled=false`
```console
$ git checkout main
$ helm upgrade --namespace moco-system moco charts/moco/ --set crds.enabled=false
Release "moco" has been upgraded. Happy Helming!
NAME: moco
LAST DEPLOYED: Tue Jun  4 16:41:41 2024
NAMESPACE: moco-system
STATUS: deployed
REVISION: 2
TEST SUITE: None

# BackupPolicy and MySQLCluster are removed.
$ kubectl get crd
NAME                                  CREATED AT
certificaterequests.cert-manager.io   2024-06-04T07:37:31Z
certificates.cert-manager.io          2024-06-04T07:37:31Z
challenges.acme.cert-manager.io       2024-06-04T07:37:32Z
clusterissuers.cert-manager.io        2024-06-04T07:37:32Z
issuers.cert-manager.io               2024-06-04T07:37:32Z
orders.acme.cert-manager.io           2024-06-04T07:37:32Z
```