### PR TITLE
Add basic Helm chart values

### DIFF
--- a/charts/moco/README.md
+++ b/charts/moco/README.md
@@ -40,8 +40,11 @@ $ helm install --create-namespace --namespace moco-system moco -f values.yaml mo
 
 | Key                       | Type   | Default                                       | Description                                                      |
 | ------------------------- | ------ | --------------------------------------------- | ---------------------------------------------------------------- |
+| replicaCount              | number | `2`                                           | Number of controller replicas.                                   |
 | image.repository          | string | `"ghcr.io/cybozu-go/moco"`                    | MOCO image repository to use.                                    |
+| image.pullPolicy          | string | `IfNotPresent`                                | MOCO image pulling policy.                                       |
 | image.tag                 | string | `{{ .Chart.AppVersion }}`                     | MOCO image tag to use.                                           |
+| imagePullSecrets          | list   | `[]`                                          | Secrets for pulling MOCO image from private repository.          |
 | resources                 | object | `{"requests":{"cpu":"100m","memory":"20Mi"}}` | resources used by moco-controller.                               |
 | crds.enabled              | bool   | `true`                                        | Install and update CRDs as part of the Helm chart.               |
 | extraArgs                 | list   | `[]`                                          | Additional command line flags to pass to moco-controller binary. |

--- a/charts/moco/templates/deployment.yaml
+++ b/charts/moco/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: moco-controller
     {{- include "moco.labels" . | nindent 4 }}
 spec:
-  replicas: 2
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/component: moco-controller
@@ -27,6 +27,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -75,6 +76,10 @@ spec:
         runAsNonRoot: true
       serviceAccountName: moco-controller-manager
       terminationGracePeriodSeconds: 10
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/moco/values.yaml
+++ b/charts/moco/values.yaml
@@ -1,10 +1,19 @@
+# replicaCount -- Number of controller replicas.
+replicaCount: 2
+
 image:
   # image.repository -- MOCO image repository to use.
   repository: ghcr.io/cybozu-go/moco
 
+  # image.pullPolicy -- MOCO image pulling policy.
+  pullPolicy: IfNotPresent
+
   # image.tag -- MOCO image tag to use.
   # @default -- `{{ .Chart.AppVersion }}`
   tag:  # 0.20.2
+
+# imagePullSecrets -- Secrets for pulling MOCO image from private repository.
+imagePullSecrets: []
 
 # resources -- resources used by moco-controller.
 resources:


### PR DESCRIPTION
Covers configurable
- replica count
- image pull policy
- reference to secrets for image pulling from authenticated container registry

Nothing really super important, but it might come handy to have these options easily configurable.