### PR TITLE
Add missing assertion method

### DIFF
--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -243,7 +243,7 @@ var _ = Describe("MySQLCluster reconciler", func() {
 				return fmt.Errorf("the user secret is not reconciled yet")
 			}
 			return nil
-		})
+		}).Should(Succeed())
 	})
 
 	It("should create certificate and copy secret", func() {


### PR DESCRIPTION
Thanks to [ginkgolinter](https://github.com/nunnatsa/ginkgolinter), the following mistake was found.

```text
controllers/mysqlcluster_controller_test.go:236:3: ginkgo-linter: "Eventually": missing assertion method. Expected "Should()" or "ShouldNot()" (ginkgolinter)
                Eventually(func() error {
                ^
```