### PR TITLE
Dead pods should not be labeled with role=replica

### DIFF
--- a/clustering/manager_test.go
+++ b/clustering/manager_test.go
@@ -676,10 +676,12 @@ var _ = Describe("manager", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "test", Name: cluster.PodName(i)}, pod)
 				g.Expect(err).NotTo(HaveOccurred())
 				switch i {
+				case 0:
+					g.Expect(pod.Labels).NotTo(HaveKey(constants.LabelMocoRole), "failing pod should not have role label")
 				case 1:
-					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RolePrimary))
+					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RolePrimary), "new primary should have role=primary")
 				default:
-					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RoleReplica))
+					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RoleReplica), "other replicas should have role=replica")
 				}
 			}
 		}).Should(Succeed())
@@ -755,7 +757,7 @@ var _ = Describe("manager", func() {
 		for i := 0; i < 3; i++ {
 			switch i {
 			case 0:
-				Expect(of.getKillConnectionsCount(cluster.PodHostname(i))).To(Equal(1))
+				Expect(of.getKillConnectionsCount(cluster.PodHostname(i))).To(BeNumerically(">", 0))
 			default:
 				Expect(of.getKillConnectionsCount(cluster.PodHostname(i))).To(Equal(0))
 			}
@@ -890,12 +892,14 @@ var _ = Describe("manager", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "test", Name: cluster.PodName(i)}, pod)
 				g.Expect(err).NotTo(HaveOccurred())
 				switch i {
+				case 0:
+					g.Expect(pod.Labels).NotTo(HaveKey(constants.LabelMocoRole), "failing pod should not have role label")
 				case 1:
-					g.Expect(pod.Labels).NotTo(HaveKey(constants.LabelMocoRole))
+					g.Expect(pod.Labels).NotTo(HaveKey(constants.LabelMocoRole), "errant pod should not have role label")
 				case 3:
-					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RolePrimary))
+					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RolePrimary), "new primary should have role=primary")
 				default:
-					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RoleReplica))
+					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RoleReplica), "other pods should have role=replica")
 				}
 			}
 		}).Should(Succeed())
@@ -947,10 +951,12 @@ var _ = Describe("manager", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "test", Name: cluster.PodName(i)}, pod)
 				g.Expect(err).NotTo(HaveOccurred())
 				switch i {
+				case 0:
+					g.Expect(pod.Labels).NotTo(HaveKey(constants.LabelMocoRole), "failing pod should not have role label")
 				case 3:
-					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RolePrimary))
+					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RolePrimary), "primary pod should have role=primary")
 				default:
-					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RoleReplica))
+					g.Expect(pod.Labels[constants.LabelMocoRole]).To(Equal(constants.RoleReplica), "other pods should have role=replica")
 				}
 			}
 		}).Should(Succeed())

--- a/clustering/manager_test.go
+++ b/clustering/manager_test.go
@@ -757,6 +757,7 @@ var _ = Describe("manager", func() {
 		for i := 0; i < 3; i++ {
 			switch i {
 			case 0:
+				// Any positive kill connection count is acceptable for the primary pod.
 				Expect(of.getKillConnectionsCount(cluster.PodHostname(i))).To(BeNumerically(">", 0))
 			default:
 				Expect(of.getKillConnectionsCount(cluster.PodHostname(i))).To(Equal(0))

--- a/clustering/operations.go
+++ b/clustering/operations.go
@@ -289,8 +289,8 @@ func (p *managerProcess) removeRoleLabel(ctx context.Context, ss *StatusSet) ([]
 	return noRoles, nil
 }
 
-func (p *managerProcess) addRoleLabel(ctx context.Context, ss *StatusSet, noRoles []int) error {
-	for _, i := range noRoles {
+func (p *managerProcess) addRoleLabel(ctx context.Context, ss *StatusSet, alive []int) error {
+	for _, i := range alive {
 		if isErrantReplica(ss, i) {
 			continue
 		}
@@ -409,7 +409,7 @@ func (p *managerProcess) configure(ctx context.Context, ss *StatusSet) (bool, er
 	}
 
 	// add new role label
-	err = p.addRoleLabel(ctx, ss, noRoles)
+	err = p.addRoleLabel(ctx, ss, alive)
 	if err != nil {
 		return false, err
 	}

--- a/clustering/operations.go
+++ b/clustering/operations.go
@@ -289,6 +289,8 @@ func (p *managerProcess) removeRoleLabel(ctx context.Context, ss *StatusSet) ([]
 	return noRoles, nil
 }
 
+// addRoleLabel adds the appropriate role label to the pods specified by the `alive` slice.
+// The `alive` parameter is a slice of pod indices that are alive and eligible for role labeling.
 func (p *managerProcess) addRoleLabel(ctx context.Context, ss *StatusSet, alive []int) error {
 	for _, i := range alive {
 		if isErrantReplica(ss, i) {


### PR DESCRIPTION
This commit fixes an issue where errant transactions could propagate through clusters due to premature role=replica labeling of dead pods.

When a MySQL pod with errant transactions dies, the current implementation adds the role=replica label to pods before checking for errant transactions. This creates a window where other clusters can mistakenly replicate from a pod with errant transactions.

Fix #801