### PR TITLE
Add setup-aqua to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,6 +90,8 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
+    - name: Setup Aqua
+      uses: ./.github/actions/setup-aqua
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:


### PR DESCRIPTION
The release workflow fails because `aqua` cannot be found.
Therefore, add the setup-aqua step.
https://github.com/cybozu-go/moco/actions/runs/15270552266/job/42945641851