### PR TITLE
Fix flaky test: wait for SemiSyncMasterWaitSessions to update after replica hang

### DIFF
--- a/pkg/dbop/status_test.go
+++ b/pkg/dbop/status_test.go
@@ -129,7 +129,13 @@ var _ = Describe("status", func() {
 		st1, err = ops[1].GetStatus(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(st0.GlobalVariables.ExecutedGTID).To(Equal(st1.GlobalVariables.ExecutedGTID))
-		Expect(st0.GlobalStatus.SemiSyncMasterWaitSessions).NotTo(Equal(0))
+		Eventually(func() int {
+			st0, err = ops[0].GetStatus(ctx)
+			if err != nil {
+				return 0
+			}
+			return st0.GlobalStatus.SemiSyncMasterWaitSessions
+		}).ShouldNot(Equal(0))
 		cancelTrx()
 	})
 })


### PR DESCRIPTION
After merging #816, the `dbtest` frequently fails due to a flaky test.

The test expects `SemiSyncMasterWaitSessions` to become non-zero immediately after creating a hanging transaction, but there can be a timing issue where the value hasn't updated yet when the assertion runs.

This PR fixes the issue by using `Eventually()` to wait for the expected state instead of checking it immediately.

Failing CI: https://github.com/cybozu-go/moco/actions/runs/16764566851/job/47467091885