### PR TITLE
fix: only set runAsUser and runAsGroup if they are not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Allow setting user and group security context for additional containers
+
 ## [0.29.0] - 2025-09-09
 
 ### Added

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -436,9 +436,13 @@ func updateContainerWithSecurityContext(container *corev1ac.ContainerApplyConfig
 	if container.SecurityContext == nil {
 		container.WithSecurityContext(corev1ac.SecurityContext())
 	}
-	container.SecurityContext.
-		WithRunAsUser(constants.ContainerUID).
-		WithRunAsGroup(constants.ContainerGID)
+
+	if container.SecurityContext.RunAsUser == nil {
+		container.SecurityContext.WithRunAsUser(constants.ContainerUID)
+	}
+	if container.SecurityContext.RunAsGroup == nil {
+		container.SecurityContext.WithRunAsGroup(constants.ContainerGID)
+	}
 }
 
 func updateContainerWithOverwriteContainers(cluster *mocov1beta2.MySQLCluster, container *corev1ac.ContainerApplyConfiguration) {

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -1139,7 +1139,7 @@ dummyKey: dummyValue
 			WithPriorityClassName("hoge").
 			WithContainers(corev1ac.Container().WithName("dummy").WithImage("dummy:latest")).
 			WithInitContainers(corev1ac.Container().WithName("init-dummy").WithImage("init-dummy:latest").
-				WithSecurityContext(corev1ac.SecurityContext().WithReadOnlyRootFilesystem(true))).
+				WithSecurityContext(corev1ac.SecurityContext().WithReadOnlyRootFilesystem(true).WithRunAsUser(0).WithRunAsGroup(0))).
 			WithVolumes(corev1ac.Volume().WithName("dummy-vol").WithEmptyDir(corev1ac.EmptyDirVolumeSource())).
 			WithSecurityContext(corev1ac.PodSecurityContext().WithFSGroup(123)).
 			WithAffinity(corev1ac.Affinity().
@@ -1282,9 +1282,9 @@ dummyKey: dummyValue
 				Expect(c.SecurityContext.ReadOnlyRootFilesystem).NotTo(BeNil())
 				Expect(*c.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
 				Expect(c.SecurityContext.RunAsUser).NotTo(BeNil())
-				Expect(*c.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
+				Expect(*c.SecurityContext.RunAsUser).To(Equal(int64(0)))
 				Expect(c.SecurityContext.RunAsGroup).NotTo(BeNil())
-				Expect(*c.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerUID)))
+				Expect(*c.SecurityContext.RunAsGroup).To(Equal(int64(0)))
 			}
 		}
 		Expect(foundInitDummyContainer).To(BeTrue())


### PR DESCRIPTION
See https://github.com/cybozu-go/moco/issues/834