### PR TITLE
use native SSA support (controller-runtime v0.22) and remove unstructured conversion

### DIFF
--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -106,7 +106,7 @@ type clientObjectConstraint[S any] interface {
 	client.Object
 }
 
-func apply[S any, T clientObjectConstraint[S], U any](ctx context.Context, r client.Client, key client.ObjectKey, expected runtime.ApplyConfiguration, extractFunc func(T, string) (U, error)) (T, error) {
+func apply[S any, T clientObjectConstraint[S], U runtime.ApplyConfiguration](ctx context.Context, r client.Client, key client.ObjectKey, expected runtime.ApplyConfiguration, extractFunc func(T, string) (U, error)) (T, error) {
 	var orig S
 	if err := r.Get(ctx, key, T(&orig)); err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get resource %s/%s: %w", key.Namespace, key.Name, err)


### PR DESCRIPTION
## Summary

This PR updates the code to use native Server-Side Apply (SSA) support introduced in controller-runtime v0.22, eliminating the previously required conversion to unstructured objects.

## Background

In controller-runtime v0.22, kubernetes-sigs/controller-runtime#3253 introduced the ability for the `client.Apply` method to accept `runtime.ApplyConfiguration` directly. This eliminates the need for:

- Converting objects via `runtime.DefaultUnstructuredConverter.ToUnstructured()`
- Creating wrappers with `client.ApplyConfigurationFromUnstructured()`

## Changes

- Updated the `apply` function signature to accept `runtime.ApplyConfiguration` directly
- Removed unstructured conversion logic

These changes make the code simpler and improve type safety.

## References

- https://github.com/kubernetes-sigs/controller-runtime/pull/3253
- https://github.com/kubernetes-sigs/controller-runtime/issues/3183