### PR TITLE
Replace deprecated rpl_semi_sync_master/slave with rpl_semi_sync_sour…

### DIFF
--- a/clustering/manager_test.go
+++ b/clustering/manager_test.go
@@ -436,11 +436,11 @@ var _ = Describe("manager", func() {
 		st0 := of.getInstanceStatus(cluster.PodHostname(0))
 		Expect(st0).NotTo(BeNil())
 		Expect(st0.GlobalVariables.SuperReadOnly).To(BeTrue())
-		Expect(st0.GlobalVariables.SemiSyncMasterEnabled).To(BeFalse())
+		Expect(st0.GlobalVariables.SemiSyncSourceEnabled).To(BeFalse())
 		for i := 1; i < 3; i++ {
 			st := of.getInstanceStatus(cluster.PodHostname(1))
 			Expect(st.GlobalVariables.SuperReadOnly).To(BeTrue())
-			Expect(st.GlobalVariables.SemiSyncSlaveEnabled).To(BeFalse())
+			Expect(st.GlobalVariables.SemiSyncReplicaEnabled).To(BeFalse())
 			Expect(st.ReplicaStatus).NotTo(BeNil())
 			Expect(st.ReplicaStatus.ReplicaIORunning).To(Equal("Yes"))
 		}
@@ -534,7 +534,7 @@ var _ = Describe("manager", func() {
 			st := of.getInstanceStatus(cluster.PodHostname(i))
 			Expect(st).NotTo(BeNil())
 			Expect(st.GlobalVariables.SuperReadOnly).To(BeTrue())
-			Expect(st.GlobalVariables.SemiSyncSlaveEnabled).To(BeFalse())
+			Expect(st.GlobalVariables.SemiSyncReplicaEnabled).To(BeFalse())
 			Expect(st.ReplicaStatus).NotTo(BeNil())
 			if i == newPrimary {
 				Expect(st.ReplicaStatus.SourceHost).To(Equal("external"))
@@ -590,12 +590,12 @@ var _ = Describe("manager", func() {
 			switch i {
 			case newPrimary:
 				Expect(st.GlobalVariables.ReadOnly).To(BeFalse())
-				Expect(st.GlobalVariables.SemiSyncMasterEnabled).To(BeTrue())
+				Expect(st.GlobalVariables.SemiSyncSourceEnabled).To(BeTrue())
 				Expect(st.ReplicaStatus).To(BeNil())
 				Expect(st.ReplicaHosts).To(HaveLen(2))
 			default:
 				Expect(st.GlobalVariables.SuperReadOnly).To(BeTrue())
-				Expect(st.GlobalVariables.SemiSyncSlaveEnabled).To(BeTrue())
+				Expect(st.GlobalVariables.SemiSyncReplicaEnabled).To(BeTrue())
 				Expect(st.ReplicaStatus).NotTo(BeNil())
 				Expect(st.ReplicaStatus.SourceHost).To(Equal(cluster.PodHostname(newPrimary)))
 			}

--- a/clustering/mock_test.go
+++ b/clustering/mock_test.go
@@ -260,7 +260,7 @@ func (o *mockOperator) ConfigureReplica(ctx context.Context, source dbop.AccessI
 	}
 	si.mu.Lock()
 	defer si.mu.Unlock()
-	if semisync && !si.status.GlobalVariables.SemiSyncMasterEnabled {
+	if semisync && !si.status.GlobalVariables.SemiSyncSourceEnabled {
 		return fmt.Errorf("configureReplica: semi-sync master is not enabled for %s", source.Host)
 	}
 
@@ -298,7 +298,7 @@ func (o *mockOperator) ConfigureReplica(ctx context.Context, source dbop.AccessI
 		ReplicaIORunning:  "Yes",
 		ReplicaSQLRunning: "Yes",
 	}
-	o.mysql.status.GlobalVariables.SemiSyncSlaveEnabled = semisync
+	o.mysql.status.GlobalVariables.SemiSyncReplicaEnabled = semisync
 	return setPodReadiness(ctx, o.cluster.PodName(o.index), true)
 }
 
@@ -311,8 +311,8 @@ func (o *mockOperator) ConfigurePrimary(ctx context.Context, waitForCount int) e
 	o.mysql.mu.Lock()
 	defer o.mysql.mu.Unlock()
 
-	o.mysql.status.GlobalVariables.WaitForSlaveCount = waitForCount
-	o.mysql.status.GlobalVariables.SemiSyncMasterEnabled = true
+	o.mysql.status.GlobalVariables.WaitForReplicaCount = waitForCount
+	o.mysql.status.GlobalVariables.SemiSyncSourceEnabled = true
 	return nil
 }
 
@@ -486,7 +486,7 @@ func (f *mockOpFactory) New(ctx context.Context, cluster *mocov1beta2.MySQLClust
 		m.status.GlobalVariables.ReadOnly = true
 		m.status.GlobalVariables.SuperReadOnly = true
 		m.status.GlobalStatus = &dbop.GlobalStatus{
-			SemiSyncMasterWaitSessions: 0,
+			SemiSyncSourceWaitSessions: 0,
 		}
 		f.mysqls[hostname] = m
 	}

--- a/clustering/operations.go
+++ b/clustering/operations.go
@@ -531,7 +531,7 @@ func (p *managerProcess) configurePrimary(ctx context.Context, ss *StatusSet) (r
 	}
 
 	waitFor := int(ss.Cluster.Spec.Replicas / 2)
-	if !pst.GlobalVariables.SemiSyncMasterEnabled || pst.GlobalVariables.WaitForSlaveCount != waitFor {
+	if !pst.GlobalVariables.SemiSyncSourceEnabled || pst.GlobalVariables.WaitForReplicaCount != waitFor {
 		redo = true
 		log.Info("enable semi-sync primary")
 		if err := op.ConfigurePrimary(ctx, waitFor); err != nil {
@@ -642,7 +642,7 @@ func (p *managerProcess) configureReplica(ctx context.Context, ss *StatusSet, in
 		Password: ss.Password.Replicator(),
 	}
 	semisync := ss.Cluster.Spec.ReplicationSourceSecretName == nil
-	if st.ReplicaStatus == nil || st.ReplicaStatus.ReplicaIORunning != "Yes" || st.ReplicaStatus.SourceHost != ai.Host || st.GlobalVariables.SemiSyncSlaveEnabled != semisync {
+	if st.ReplicaStatus == nil || st.ReplicaStatus.ReplicaIORunning != "Yes" || st.ReplicaStatus.SourceHost != ai.Host || st.GlobalVariables.SemiSyncReplicaEnabled != semisync {
 		redo = true
 		log.Info("start replication", "instance", index, "semisync", semisync)
 		if err := op.ConfigureReplica(ctx, ai, semisync); err != nil {

--- a/clustering/status.go
+++ b/clustering/status.go
@@ -299,9 +299,9 @@ func (p *managerProcess) GatherStatus(ctx context.Context) (*StatusSet, error) {
 		if ist == nil {
 			continue
 		}
-		if ist.GlobalStatus.SemiSyncMasterWaitSessions > 0 {
+		if ist.GlobalStatus.SemiSyncSourceWaitSessions > 0 {
 			ss.MySQLStatus[i] = nil
-			log.Info("Detected a hangup replica. rpl_semi_sync_master_wait_sessions is greater than 0.", "instance", i)
+			log.Info("Detected a hangup replica. semi_sync_source_wait_sessions is greater than 0.", "instance", i)
 		}
 	}
 

--- a/pkg/dbop/operator.go
+++ b/pkg/dbop/operator.go
@@ -107,12 +107,21 @@ func (f defaultFactory) New(ctx context.Context, cluster *mocov1beta2.MySQLClust
 	}
 	db.SetMaxIdleConns(1)
 	db.SetConnMaxIdleTime(30 * time.Second)
+
+	// Detect semi-sync plugin type. If the instance is unreachable (e.g. during failover),
+	// default to new names. Subsequent queries will also fail and be handled gracefully.
+	ss, _ := DetectSemiSyncNames(ctx, db)
+	if ss == nil {
+		ss = &NewSemiSyncNames
+	}
+
 	return &operator{
 		namespace: cluster.Namespace,
 		name:      cluster.PodName(index),
 		passwd:    pwd,
 		index:     index,
 		db:        db,
+		semisync:  ss,
 	}, nil
 }
 
@@ -124,6 +133,7 @@ type operator struct {
 	passwd    *password.MySQLPassword
 	index     int
 	db        *sqlx.DB
+	semisync  *SemiSyncNames
 }
 
 var _ Operator = &operator{}

--- a/pkg/dbop/operator.go
+++ b/pkg/dbop/operator.go
@@ -2,7 +2,6 @@ package dbop
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/cybozu-go/moco/pkg/constants"
 	"github.com/cybozu-go/moco/pkg/password"
+	"github.com/go-logr/logr"
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 )
@@ -81,16 +81,19 @@ type defaultFactory struct {
 var _ OperatorFactory = defaultFactory{}
 
 // NewFactory returns a new OperatorFactory that resolves instance IP address using `r`.
-// If `r.Resolve` returns an error, the `New` method will return a NopOperator.
+// If `r.Resolve` or semi-sync plugin detection fails, the `New` method will return
+// a NopOperator so that a single unreachable instance does not abort the whole
+// reconcile cycle.
 func NewFactory(r Resolver) OperatorFactory {
 	return defaultFactory{r: r}
 }
 
 func (f defaultFactory) New(ctx context.Context, cluster *mocov1beta2.MySQLCluster, pwd *password.MySQLPassword, index int) (Operator, error) {
+	nopName := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.PodName(index))
 	addr, err := f.r.Resolve(ctx, cluster, index)
 	//nolint:nilerr
 	if err != nil {
-		return NopOperator{name: fmt.Sprintf("%s/%s", cluster.Namespace, cluster.PodName(index))}, nil
+		return NopOperator{name: nopName}, nil
 	}
 
 	cfg := mysql.NewConfig()
@@ -109,17 +112,22 @@ func (f defaultFactory) New(ctx context.Context, cluster *mocov1beta2.MySQLClust
 	db.SetMaxIdleConns(1)
 	db.SetConnMaxIdleTime(30 * time.Second)
 
-	// Detect which semi-sync plugin variant is installed. A failure here means
-	// the DB is reachable but information_schema returned an error; propagate
-	// so the reconciler retries on the next iteration instead of silently
-	// falling back to the new names (which would target nonexistent variables
-	// on a legacy-plugin cluster).
+	// Detect which semi-sync plugin variant is installed. On error (mysqld
+	// unreachable, information_schema query failure, etc.) fall back to a
+	// NopOperator instead of propagating the error: GatherStatus treats a
+	// New() error as fatal for the whole cluster, while per-instance
+	// GetStatus errors are tolerated. Mapping detection failures to a Nop
+	// matches the Resolver-failure behavior above and preserves reconciler
+	// availability when a single replica is temporarily unhealthy.
 	ss, err := DetectSemiSyncNames(ctx, db)
 	if err != nil {
+		logr.FromContextOrDiscard(ctx).Error(err, "failed to detect semi-sync plugin; falling back to NopOperator",
+			"instance", nopName)
 		if cerr := db.Close(); cerr != nil {
-			err = errors.Join(err, cerr)
+			logr.FromContextOrDiscard(ctx).Error(cerr, "failed to close db after semi-sync detection error",
+				"instance", nopName)
 		}
-		return nil, fmt.Errorf("failed to detect semi-sync plugin for %s: %w", cluster.PodName(index), err)
+		return NopOperator{name: nopName}, nil
 	}
 
 	return &operator{

--- a/pkg/dbop/operator.go
+++ b/pkg/dbop/operator.go
@@ -2,6 +2,7 @@ package dbop
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -108,11 +109,17 @@ func (f defaultFactory) New(ctx context.Context, cluster *mocov1beta2.MySQLClust
 	db.SetMaxIdleConns(1)
 	db.SetConnMaxIdleTime(30 * time.Second)
 
-	// Detect semi-sync plugin type. If the instance is unreachable (e.g. during failover),
-	// default to new names. Subsequent queries will also fail and be handled gracefully.
-	ss, _ := DetectSemiSyncNames(ctx, db)
-	if ss == nil {
-		ss = &NewSemiSyncNames
+	// Detect which semi-sync plugin variant is installed. A failure here means
+	// the DB is reachable but information_schema returned an error; propagate
+	// so the reconciler retries on the next iteration instead of silently
+	// falling back to the new names (which would target nonexistent variables
+	// on a legacy-plugin cluster).
+	ss, err := DetectSemiSyncNames(ctx, db)
+	if err != nil {
+		if cerr := db.Close(); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+		return nil, fmt.Errorf("failed to detect semi-sync plugin for %s: %w", cluster.PodName(index), err)
 	}
 
 	return &operator{
@@ -133,7 +140,7 @@ type operator struct {
 	passwd    *password.MySQLPassword
 	index     int
 	db        *sqlx.DB
-	semisync  *SemiSyncNames
+	semisync  SemiSyncNames
 }
 
 var _ Operator = &operator{}

--- a/pkg/dbop/replication.go
+++ b/pkg/dbop/replication.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const semiSyncMasterTimeout = 24 * 60 * 60 * 1000
+const semiSyncSourceTimeout = 24 * 60 * 60 * 1000
 
 func (o *operator) ConfigureReplica(ctx context.Context, primary AccessInfo, semisync bool) error {
 	if _, err := o.db.ExecContext(ctx, `STOP REPLICA`); err != nil {
@@ -27,11 +27,11 @@ func (o *operator) ConfigureReplica(ctx context.Context, primary AccessInfo, sem
 	if _, err := o.db.NamedExecContext(ctx, cmd, primary); err != nil {
 		return fmt.Errorf("failed to change primary: %w", err)
 	}
-	if _, err := o.db.ExecContext(ctx, "SET GLOBAL rpl_semi_sync_slave_enabled=?", semisync); err != nil {
-		return fmt.Errorf("failed to set rpl_semi_sync_slave_enabled: %w", err)
+	if _, err := o.db.ExecContext(ctx, fmt.Sprintf("SET GLOBAL %s=?", o.semisync.ReplicaEnabled), semisync); err != nil {
+		return fmt.Errorf("failed to set %s: %w", o.semisync.ReplicaEnabled, err)
 	}
-	if _, err := o.db.ExecContext(ctx, "SET GLOBAL rpl_semi_sync_master_enabled=OFF"); err != nil {
-		return fmt.Errorf("failed to disable rpl_semi_sync_master_enabled: %w", err)
+	if _, err := o.db.ExecContext(ctx, fmt.Sprintf("SET GLOBAL %s=OFF", o.semisync.SourceEnabled)); err != nil {
+		return fmt.Errorf("failed to disable %s: %w", o.semisync.SourceEnabled, err)
 	}
 	if _, err := o.db.ExecContext(ctx, `START REPLICA`); err != nil {
 		return fmt.Errorf("failed to start replica: %w", err)
@@ -40,13 +40,13 @@ func (o *operator) ConfigureReplica(ctx context.Context, primary AccessInfo, sem
 }
 
 func (o *operator) ConfigurePrimary(ctx context.Context, waitForCount int) error {
-	if _, err := o.db.ExecContext(ctx, "SET GLOBAL rpl_semi_sync_master_timeout=?", semiSyncMasterTimeout); err != nil {
-		return fmt.Errorf("failed to set rpl_semi_sync_master_timeout count: %w", err)
+	if _, err := o.db.ExecContext(ctx, fmt.Sprintf("SET GLOBAL %s=?", o.semisync.SourceTimeout), semiSyncSourceTimeout); err != nil {
+		return fmt.Errorf("failed to set %s: %w", o.semisync.SourceTimeout, err)
 	}
-	if _, err := o.db.ExecContext(ctx, "SET GLOBAL rpl_semi_sync_master_wait_for_slave_count=?", waitForCount); err != nil {
-		return fmt.Errorf("failed to set rpl_semi_sync_master_wait_for_slave_count count: %w", err)
+	if _, err := o.db.ExecContext(ctx, fmt.Sprintf("SET GLOBAL %s=?", o.semisync.WaitForReplicaCount), waitForCount); err != nil {
+		return fmt.Errorf("failed to set %s: %w", o.semisync.WaitForReplicaCount, err)
 	}
-	if _, err := o.db.ExecContext(ctx, "SET GLOBAL rpl_semi_sync_master_enabled=ON"); err != nil {
+	if _, err := o.db.ExecContext(ctx, fmt.Sprintf("SET GLOBAL %s=ON", o.semisync.SourceEnabled)); err != nil {
 		return fmt.Errorf("failed to enable semi-sync primary: %w", err)
 	}
 	return nil

--- a/pkg/dbop/replication_test.go
+++ b/pkg/dbop/replication_test.go
@@ -80,8 +80,8 @@ var _ = Describe("replication", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(st1.GlobalVariables.ExecutedGTID).To(Equal(st0.GlobalVariables.ExecutedGTID))
 		Expect(st1.GlobalVariables.SuperReadOnly).To(BeTrue())
-		Expect(st1.GlobalVariables.SemiSyncMasterEnabled).To(BeFalse())
-		Expect(st1.GlobalVariables.SemiSyncSlaveEnabled).To(BeFalse())
+		Expect(st1.GlobalVariables.SemiSyncSourceEnabled).To(BeFalse())
+		Expect(st1.GlobalVariables.SemiSyncReplicaEnabled).To(BeFalse())
 
 		By("checking WaitForGTID works")
 		err = ops[1].StopReplicaIOThread(ctx)
@@ -134,9 +134,9 @@ var _ = Describe("replication", func() {
 		st2, err := ops[2].GetStatus(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(st2.GlobalVariables.ExecutedGTID).To(Equal(st1.GlobalVariables.ExecutedGTID))
-		Expect(st1.GlobalVariables.SemiSyncMasterEnabled).To(BeFalse())
-		Expect(st1.GlobalVariables.SemiSyncSlaveEnabled).To(BeFalse())
-		Expect(st2.GlobalVariables.SemiSyncSlaveEnabled).To(BeFalse())
+		Expect(st1.GlobalVariables.SemiSyncSourceEnabled).To(BeFalse())
+		Expect(st1.GlobalVariables.SemiSyncReplicaEnabled).To(BeFalse())
+		Expect(st2.GlobalVariables.SemiSyncReplicaEnabled).To(BeFalse())
 
 		By("promoting 2 as the new intermediate primary")
 		err = ops[2].StopReplicaIOThread(ctx)

--- a/pkg/dbop/semisync.go
+++ b/pkg/dbop/semisync.go
@@ -1,0 +1,90 @@
+package dbop
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// SemiSyncNames holds plugin names and variable names for the installed semi-sync plugin variant.
+type SemiSyncNames struct {
+	// Plugin names
+	SourcePluginName  string
+	ReplicaPluginName string
+
+	// System variables (source side)
+	SourceEnabled       string
+	SourceTimeout       string
+	WaitForReplicaCount string
+
+	// System variables (replica side)
+	ReplicaEnabled string
+
+	// Status variables
+	SourceWaitSessions string
+}
+
+// NewSemiSyncNames is the name set for the new semi-sync plugins (rpl_semi_sync_source/replica).
+var NewSemiSyncNames = SemiSyncNames{
+	SourcePluginName:    "rpl_semi_sync_source",
+	ReplicaPluginName:   "rpl_semi_sync_replica",
+	SourceEnabled:       "rpl_semi_sync_source_enabled",
+	SourceTimeout:       "rpl_semi_sync_source_timeout",
+	WaitForReplicaCount: "rpl_semi_sync_source_wait_for_replica_count",
+	ReplicaEnabled:      "rpl_semi_sync_replica_enabled",
+	SourceWaitSessions:  "Rpl_semi_sync_source_wait_sessions",
+}
+
+// LegacySemiSyncNames is the name set for the deprecated semi-sync plugins (rpl_semi_sync_master/slave).
+var LegacySemiSyncNames = SemiSyncNames{
+	SourcePluginName:    "rpl_semi_sync_master",
+	ReplicaPluginName:   "rpl_semi_sync_slave",
+	SourceEnabled:       "rpl_semi_sync_master_enabled",
+	SourceTimeout:       "rpl_semi_sync_master_timeout",
+	WaitForReplicaCount: "rpl_semi_sync_master_wait_for_slave_count",
+	ReplicaEnabled:      "rpl_semi_sync_slave_enabled",
+	SourceWaitSessions:  "Rpl_semi_sync_master_wait_sessions",
+}
+
+// DetectSemiSyncNames detects which semi-sync plugin is installed and returns the appropriate name set.
+// If neither plugin is installed, it returns NewSemiSyncNames (for fresh installations).
+func DetectSemiSyncNames(ctx context.Context, db *sqlx.DB) (*SemiSyncNames, error) {
+	// Check for new plugin first
+	status, err := getPluginStatus(ctx, db, NewSemiSyncNames.SourcePluginName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check semi-sync source plugin: %w", err)
+	}
+	if status == "ACTIVE" {
+		return &NewSemiSyncNames, nil
+	}
+
+	// Check for legacy plugin
+	status, err = getPluginStatus(ctx, db, LegacySemiSyncNames.SourcePluginName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check semi-sync master plugin: %w", err)
+	}
+	if status == "ACTIVE" {
+		return &LegacySemiSyncNames, nil
+	}
+
+	// Neither installed — assume new names for fresh install
+	return &NewSemiSyncNames, nil
+}
+
+// getPluginStatus returns the PLUGIN_STATUS for the given plugin name.
+// Returns "" if the plugin is not installed, or the status string ("ACTIVE", "INACTIVE", "DISABLED", etc.).
+func getPluginStatus(ctx context.Context, db *sqlx.DB, name string) (string, error) {
+	var status string
+	err := db.GetContext(ctx, &status,
+		"SELECT PLUGIN_STATUS FROM information_schema.plugins WHERE PLUGIN_NAME=?", name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to check plugin %s: %w", name, err)
+	}
+	return status, nil
+}

--- a/pkg/dbop/semisync.go
+++ b/pkg/dbop/semisync.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -50,28 +51,41 @@ var LegacySemiSyncNames = SemiSyncNames{
 }
 
 // DetectSemiSyncNames detects which semi-sync plugin is installed and returns the appropriate name set.
-// If neither plugin is installed, it returns NewSemiSyncNames (for fresh installations).
-func DetectSemiSyncNames(ctx context.Context, db *sqlx.DB) (*SemiSyncNames, error) {
-	// Check for new plugin first
-	status, err := getPluginStatus(ctx, db, NewSemiSyncNames.SourcePluginName)
+//
+// The new plugin (rpl_semi_sync_source) is preferred when ACTIVE; the legacy plugin
+// (rpl_semi_sync_master) is used only when it is the sole ACTIVE one. If neither
+// plugin is ACTIVE — for example on a fresh instance whose moco-agent has not yet
+// installed the plugins — NewSemiSyncNames is returned so subsequent operations
+// target the modern variable names.
+//
+// When a plugin row exists but is not ACTIVE (DISABLED / INACTIVE / DELETED), a
+// warning is logged because subsequent SET/SELECT against the plugin's system
+// variables will fail — system variables are not exposed for non-ACTIVE plugins.
+func DetectSemiSyncNames(ctx context.Context, db *sqlx.DB) (SemiSyncNames, error) {
+	newStatus, err := getPluginStatus(ctx, db, NewSemiSyncNames.SourcePluginName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check semi-sync source plugin: %w", err)
+		return SemiSyncNames{}, fmt.Errorf("failed to check semi-sync source plugin: %w", err)
 	}
-	if status == "ACTIVE" {
-		return &NewSemiSyncNames, nil
+	if newStatus == "ACTIVE" {
+		return NewSemiSyncNames, nil
 	}
 
-	// Check for legacy plugin
-	status, err = getPluginStatus(ctx, db, LegacySemiSyncNames.SourcePluginName)
+	legacyStatus, err := getPluginStatus(ctx, db, LegacySemiSyncNames.SourcePluginName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check semi-sync master plugin: %w", err)
+		return SemiSyncNames{}, fmt.Errorf("failed to check semi-sync master plugin: %w", err)
 	}
-	if status == "ACTIVE" {
-		return &LegacySemiSyncNames, nil
+	if legacyStatus == "ACTIVE" {
+		return LegacySemiSyncNames, nil
 	}
 
-	// Neither installed — assume new names for fresh install
-	return &NewSemiSyncNames, nil
+	if newStatus != "" || legacyStatus != "" {
+		logr.FromContextOrDiscard(ctx).Info(
+			"semi-sync plugin is registered but not ACTIVE; semi-sync operations may fail",
+			"newPlugin", NewSemiSyncNames.SourcePluginName, "newStatus", newStatus,
+			"legacyPlugin", LegacySemiSyncNames.SourcePluginName, "legacyStatus", legacyStatus,
+		)
+	}
+	return NewSemiSyncNames, nil
 }
 
 // getPluginStatus returns the PLUGIN_STATUS for the given plugin name.

--- a/pkg/dbop/status_test.go
+++ b/pkg/dbop/status_test.go
@@ -44,10 +44,10 @@ var _ = Describe("status", func() {
 		Expect(status.GlobalVariables.PurgedGTID).To(BeEmpty())
 		Expect(status.GlobalVariables.ReadOnly).To(BeTrue())
 		Expect(status.GlobalVariables.SuperReadOnly).To(BeTrue())
-		Expect(status.GlobalVariables.WaitForSlaveCount).To(Equal(1))
-		Expect(status.GlobalVariables.SemiSyncMasterEnabled).To(BeFalse())
-		Expect(status.GlobalVariables.SemiSyncSlaveEnabled).To(BeFalse())
-		Expect(status.GlobalStatus.SemiSyncMasterWaitSessions).To(Equal(0))
+		Expect(status.GlobalVariables.WaitForReplicaCount).To(Equal(1))
+		Expect(status.GlobalVariables.SemiSyncSourceEnabled).To(BeFalse())
+		Expect(status.GlobalVariables.SemiSyncReplicaEnabled).To(BeFalse())
+		Expect(status.GlobalStatus.SemiSyncSourceWaitSessions).To(Equal(0))
 
 		By("writing data and checking gtid_executed")
 		_, err = ops[0].db.Exec("SET GLOBAL read_only=0")
@@ -65,10 +65,10 @@ var _ = Describe("status", func() {
 		Expect(status.GlobalVariables.PurgedGTID).To(BeEmpty())
 		Expect(status.GlobalVariables.ReadOnly).To(BeFalse())
 		Expect(status.GlobalVariables.SuperReadOnly).To(BeFalse())
-		Expect(status.GlobalVariables.WaitForSlaveCount).To(Equal(1))
-		Expect(status.GlobalVariables.SemiSyncMasterEnabled).To(BeFalse())
-		Expect(status.GlobalVariables.SemiSyncSlaveEnabled).To(BeFalse())
-		Expect(status.GlobalStatus.SemiSyncMasterWaitSessions).To(Equal(0))
+		Expect(status.GlobalVariables.WaitForReplicaCount).To(Equal(1))
+		Expect(status.GlobalVariables.SemiSyncSourceEnabled).To(BeFalse())
+		Expect(status.GlobalVariables.SemiSyncReplicaEnabled).To(BeFalse())
+		Expect(status.GlobalStatus.SemiSyncSourceWaitSessions).To(Equal(0))
 
 		By("enabling semi-sync master")
 		err = ops[0].ConfigurePrimary(ctx, 1)
@@ -76,10 +76,10 @@ var _ = Describe("status", func() {
 		status, err = ops[0].GetStatus(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).NotTo(BeNil())
-		Expect(status.GlobalVariables.WaitForSlaveCount).To(Equal(1))
-		Expect(status.GlobalVariables.SemiSyncMasterEnabled).To(BeTrue())
-		Expect(status.GlobalVariables.SemiSyncSlaveEnabled).To(BeFalse())
-		Expect(status.GlobalStatus.SemiSyncMasterWaitSessions).To(Equal(0))
+		Expect(status.GlobalVariables.WaitForReplicaCount).To(Equal(1))
+		Expect(status.GlobalVariables.SemiSyncSourceEnabled).To(BeTrue())
+		Expect(status.GlobalVariables.SemiSyncReplicaEnabled).To(BeFalse())
+		Expect(status.GlobalStatus.SemiSyncSourceWaitSessions).To(Equal(0))
 
 		By("enabling semi-sync replica")
 		err = ops[1].ConfigureReplica(ctx, AccessInfo{
@@ -105,8 +105,8 @@ var _ = Describe("status", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(st1.GlobalVariables.ExecutedGTID).To(Equal(st0.GlobalVariables.ExecutedGTID))
 		Expect(st1.GlobalVariables.SuperReadOnly).To(BeTrue())
-		Expect(st1.GlobalVariables.SemiSyncMasterEnabled).To(BeFalse())
-		Expect(st1.GlobalVariables.SemiSyncSlaveEnabled).To(BeTrue())
+		Expect(st1.GlobalVariables.SemiSyncSourceEnabled).To(BeFalse())
+		Expect(st1.GlobalVariables.SemiSyncReplicaEnabled).To(BeTrue())
 
 		By("create hangup transaction")
 		err = ops[1].StopReplicaIOThread(ctx)
@@ -134,7 +134,7 @@ var _ = Describe("status", func() {
 			if err != nil {
 				return 0
 			}
-			return st0.GlobalStatus.SemiSyncMasterWaitSessions
+			return st0.GlobalStatus.SemiSyncSourceWaitSessions
 		}).ShouldNot(Equal(0))
 		cancelTrx()
 	})

--- a/pkg/dbop/types.go
+++ b/pkg/dbop/types.go
@@ -21,31 +21,20 @@ type MySQLInstanceStatus struct {
 	CloneStatus     *CloneStatus   // may not be available
 }
 
-var statusGlobalVars = []string{
-	"@@server_uuid",
-	"@@gtid_executed",
-	"@@gtid_purged",
-	"@@read_only",
-	"@@super_read_only",
-	"@@rpl_semi_sync_master_wait_for_slave_count",
-	"@@rpl_semi_sync_master_enabled",
-	"@@rpl_semi_sync_slave_enabled",
-}
-
 // GlobalVariables defines the observed global variable values of a MySQL instance
 type GlobalVariables struct {
-	UUID                  string `db:"@@server_uuid"`
-	ExecutedGTID          string `db:"@@gtid_executed"`
-	PurgedGTID            string `db:"@@gtid_purged"`
-	ReadOnly              bool   `db:"@@read_only"`
-	SuperReadOnly         bool   `db:"@@super_read_only"`
-	WaitForSlaveCount     int    `db:"@@rpl_semi_sync_master_wait_for_slave_count"`
-	SemiSyncMasterEnabled bool   `db:"@@rpl_semi_sync_master_enabled"`
-	SemiSyncSlaveEnabled  bool   `db:"@@rpl_semi_sync_slave_enabled"`
+	UUID                   string `db:"@@server_uuid"`
+	ExecutedGTID           string `db:"@@gtid_executed"`
+	PurgedGTID             string `db:"@@gtid_purged"`
+	ReadOnly               bool   `db:"@@read_only"`
+	SuperReadOnly          bool   `db:"@@super_read_only"`
+	WaitForReplicaCount    int    `db:"wait_for_replica_count"`
+	SemiSyncSourceEnabled  bool   `db:"source_enabled"`
+	SemiSyncReplicaEnabled bool   `db:"replica_enabled"`
 }
 
 type GlobalStatus struct {
-	SemiSyncMasterWaitSessions int
+	SemiSyncSourceWaitSessions int
 }
 
 // ReplicaHost defines the columns from `SHOW REPLICAS`


### PR DESCRIPTION
…ce/replica

Migrate semi-synchronous replication from the deprecated master/slave plugins to the new source/replica plugins for MySQL 9.x compatibility.

Key changes:
- Add SemiSyncNames type and DetectSemiSyncNames() to dynamically detect which semi-sync plugin is installed via information_schema.plugins
- Make all semi-sync variable references dynamic (SET GLOBAL, SELECT) based on the detected plugin type
- Rename struct fields: SemiSyncMasterEnabled -> SemiSyncSourceEnabled, SemiSyncSlaveEnabled -> SemiSyncReplicaEnabled, WaitForSlaveCount -> WaitForReplicaCount
- Update test helpers to install new plugin names

Existing clusters with legacy plugins continue to work because the controller detects the installed plugin at runtime. Migration happens when moco-agent re-initializes plugins on Pod restart.

Ref: cybozu-go/moco#847 https://github.com/cybozu-go/moco-agent/pull/117