### PR TITLE
Update validation enum for OverwriteableContainerName

### DIFF
--- a/api/v1beta2/mysqlcluster_types.go
+++ b/api/v1beta2/mysqlcluster_types.go
@@ -454,7 +454,7 @@ type PodTemplateSpec struct {
 }
 
 // OverwriteableContainerName is the name of the container.
-// +kubebuilder:validation:Enum=agent;moco-init;slow-log;mysqld-exporter
+// +kubebuilder:validation:Enum=agent;copy-moco-init;moco-init;slow-log;mysqld-exporter
 type OverwriteableContainerName string
 
 // String implements the fmt.Stringer interface.
@@ -464,6 +464,7 @@ func (c OverwriteableContainerName) String() string {
 
 const (
 	AgentContainerName             OverwriteableContainerName = constants.AgentContainerName
+	CopyInitContainerName          OverwriteableContainerName = constants.CopyInitContainerName
 	InitContainerName              OverwriteableContainerName = constants.InitContainerName
 	SlowQueryLogAgentContainerName OverwriteableContainerName = constants.SlowQueryLogAgentContainerName
 	ExporterContainerName          OverwriteableContainerName = constants.ExporterContainerName

--- a/charts/moco/templates/generated/crds/moco_crds.yaml
+++ b/charts/moco/templates/generated/crds/moco_crds.yaml
@@ -2361,6 +2361,7 @@ spec:
                             description: Name of the container to overwrite.
                             enum:
                               - agent
+                              - copy-moco-init
                               - moco-init
                               - slow-log
                               - mysqld-exporter

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -127,6 +127,7 @@ spec:
                           description: Name of the container to overwrite.
                           enum:
                           - agent
+                          - copy-moco-init
                           - moco-init
                           - slow-log
                           - mysqld-exporter

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
@@ -127,6 +127,7 @@ spec:
                           description: Name of the container to overwrite.
                           enum:
                           - agent
+                          - copy-moco-init
                           - moco-init
                           - slow-log
                           - mysqld-exporter

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -1126,6 +1126,15 @@ dummyKey: dummyValue
 					WithCapabilities(corev1ac.Capabilities().WithDrop("ALL"))),
 			},
 			{
+				Name: mocov1beta2.CopyInitContainerName,
+				Resources: (*mocov1beta2.ResourceRequirementsApplyConfiguration)(corev1ac.ResourceRequirements().
+					WithLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("150m")}).
+					WithRequests(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("150m")}),
+				),
+				SecurityContext: (*mocov1beta2.SecurityContextApplyConfiguration)(corev1ac.SecurityContext().
+					WithCapabilities(corev1ac.Capabilities().WithDrop("ALL"))),
+			},
+			{
 				Name: mocov1beta2.InitContainerName,
 				Resources: (*mocov1beta2.ResourceRequirementsApplyConfiguration)(corev1ac.ResourceRequirements().
 					WithLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")}).
@@ -1271,6 +1280,12 @@ dummyKey: dummyValue
 		for _, c := range sts.Spec.Template.Spec.InitContainers {
 			Expect(c.SecurityContext).NotTo(BeNil())
 			switch c.Name {
+			case constants.CopyInitContainerName:
+				Expect(c.Resources.Requests).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("150m")}))
+				Expect(c.Resources.Limits).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("150m")}))
+				Expect(c.SecurityContext.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+				Expect(c.SecurityContext.RunAsUser).To(BeNil())
+				Expect(c.SecurityContext.RunAsGroup).To(BeNil())
 			case constants.InitContainerName:
 				Expect(c.Args).To(ContainElement(fmt.Sprintf("%s=1", constants.MocoInitLowerCaseTableNamesFlag)))
 				Expect(c.Resources.Requests).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")}))


### PR DESCRIPTION
Allow `copy-moco-init` to be adjusted.

Fixes #904