### PR TITLE
feat: opt-in deactivation of ChecksumValidation for S3 compatibility

### DIFF
--- a/api/v1beta2/job_types.go
+++ b/api/v1beta2/job_types.go
@@ -205,6 +205,16 @@ type BucketConfig struct {
 	// Path to SSL CA certificate file used in addition to system default.
 	// +optional
 	CaCert string `json:"caCert,omitempty"`
+
+	// NoChecksumValidation disables checksum calculation and validation on S3 requests
+	// and responses. Enable this when using an S3-compatible object storage that does not
+	// support AWS-style checksum headers (e.g. some on-premises or third-party S3
+	// implementations). By default, the AWS SDK calculates and validates checksums on all
+	// supported operations, which ensures data integrity but may be rejected by
+	// non-compliant S3 servers.
+	// This option has no effect when backendType is set to gcs or azure.
+	// +optional
+	NoChecksumValidation bool `json:"noChecksumValidation,omitempty"`
 }
 
 // AffinityApplyConfiguration is the type defined to implement the DeepCopy method.

--- a/charts/moco/templates/generated/crds/moco_crds.yaml
+++ b/charts/moco/templates/generated/crds/moco_crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -463,6 +463,9 @@ spec:
                           description: The API endpoint URL.
                           pattern: ^https?://.*
                           type: string
+                        noChecksumValidation:
+                          description: NoChecksumValidation disables checksum...
+                          type: boolean
                         region:
                           description: The region of the bucket.
                           type: string
@@ -2221,7 +2224,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/moco-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -6602,6 +6605,9 @@ spec:
                               description: The API endpoint URL.
                               pattern: ^https?://.*
                               type: string
+                            noChecksumValidation:
+                              description: NoChecksumValidation disables checksum...
+                              type: boolean
                             region:
                               description: The region of the bucket.
                               type: string

--- a/cmd/moco-backup/cmd/root.go
+++ b/cmd/moco-backup/cmd/root.go
@@ -19,13 +19,14 @@ import (
 )
 
 var commonArgs struct {
-	workDir        string
-	threads        int
-	region         string
-	endpointURL    string
-	usePathStyle   bool
-	backendType    string
-	caCertFilePath string
+	workDir              string
+	threads              int
+	region               string
+	endpointURL          string
+	usePathStyle         bool
+	backendType          string
+	caCertFilePath       string
+	noChecksumValidation bool
 }
 
 func makeBucket(bucketName string) (bucket.Bucket, error) {
@@ -51,6 +52,9 @@ func makeS3Bucket(bucketName string) (bucket.Bucket, error) {
 	}
 	if commonArgs.usePathStyle {
 		opts = append(opts, bucket.WithPathStyle())
+	}
+	if commonArgs.noChecksumValidation {
+		opts = append(opts, bucket.WithNoChecksumValidation())
 	}
 	if len(commonArgs.caCertFilePath) > 0 {
 		caCertFile, err := os.ReadFile(commonArgs.caCertFilePath)
@@ -151,4 +155,5 @@ func init() {
 	pf.BoolVar(&commonArgs.usePathStyle, "use-path-style", false, "Use path-style S3 API")
 	pf.StringVar(&commonArgs.backendType, "backend-type", "s3", "The identifier for the object storage to be used.")
 	pf.StringVar(&commonArgs.caCertFilePath, "ca-cert", "", "Path to SSL CA certificate file used in addition to system default")
+	pf.BoolVar(&commonArgs.noChecksumValidation, "no-checksum-validation", false, "Disable S3 checksum calculation and validation for compatibility with non-AWS S3 implementations")
 }

--- a/config/crd/bases/moco.cybozu.com_backuppolicies.yaml
+++ b/config/crd/bases/moco.cybozu.com_backuppolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: backuppolicies.moco.cybozu.com
 spec:
   group: moco.cybozu.com
@@ -485,6 +485,9 @@ spec:
                         description: The API endpoint URL.
                         pattern: ^https?://.*
                         type: string
+                      noChecksumValidation:
+                        description: NoChecksumValidation disables checksum...
+                        type: boolean
                       region:
                         description: The region of the bucket.
                         type: string

--- a/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
+++ b/config/crd/bases/moco.cybozu.com_mysqlclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: mysqlclusters.moco.cybozu.com
 spec:
   group: moco.cybozu.com
@@ -4703,6 +4703,9 @@ spec:
                             description: The API endpoint URL.
                             pattern: ^https?://.*
                             type: string
+                          noChecksumValidation:
+                            description: NoChecksumValidation disables checksum...
+                            type: boolean
                           region:
                             description: The region of the bucket.
                             type: string

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_backuppolicies.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_backuppolicies.moco.cybozu.com.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: backuppolicies.moco.cybozu.com
 spec:
   group: moco.cybozu.com
@@ -484,6 +484,9 @@ spec:
                         description: The API endpoint URL.
                         pattern: ^https?://.*
                         type: string
+                      noChecksumValidation:
+                        description: NoChecksumValidation disables checksum...
+                        type: boolean
                       region:
                         description: The region of the bucket.
                         type: string

--- a/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
+++ b/config/crd/tests/apiextensions.k8s.io_v1_customresourcedefinition_mysqlclusters.moco.cybozu.com.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: mysqlclusters.moco.cybozu.com
 spec:
   group: moco.cybozu.com
@@ -4703,6 +4703,9 @@ spec:
                             description: The API endpoint URL.
                             pattern: ^https?://.*
                             type: string
+                          noChecksumValidation:
+                            description: NoChecksumValidation disables checksum...
+                            type: boolean
                           region:
                             description: The region of the bucket.
                             type: string

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -1116,6 +1116,9 @@ func bucketArgs(bc mocov1beta2.BucketConfig) []string {
 	if bc.CaCert != "" {
 		args = append(args, "--ca-cert="+bc.CaCert)
 	}
+	if bc.NoChecksumValidation {
+		args = append(args, "--no-checksum-validation")
+	}
 
 	return append(args, bc.BucketName)
 }

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -1549,6 +1549,38 @@ dummyKey: dummyValue
 			return nil
 		}).Should(Succeed())
 
+		By("enabling no-checksum-validation in backup policy")
+		bp = &mocov1beta2.BackupPolicy{}
+		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "test", Name: "test-policy"}, bp)
+		Expect(err).NotTo(HaveOccurred())
+		bp.Spec.JobConfig.BucketConfig.NoChecksumValidation = true
+		err = k8sClient.Update(ctx, bp)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() error {
+			cj = &batchv1.CronJob{}
+			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "test", Name: cluster.BackupCronJobName()}, cj); err != nil {
+				return err
+			}
+			for _, arg := range cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args {
+				if arg == "--no-checksum-validation" {
+					return nil
+				}
+			}
+			return errors.New("--no-checksum-validation flag not found in CronJob args")
+		}).Should(Succeed())
+
+		c = &cj.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+		Expect(c.Args).To(Equal([]string{
+			"backup",
+			"--threads=1",
+			"--backend-type=s3",
+			"--no-checksum-validation",
+			"mybucket2",
+			"test",
+			"test",
+		}))
+
 		By("disabling backup")
 		cluster = &mocov1beta2.MySQLCluster{}
 		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "test", Name: "test"}, cluster)

--- a/docs/crd_backuppolicy_v1beta2.md
+++ b/docs/crd_backuppolicy_v1beta2.md
@@ -62,6 +62,7 @@ BucketConfig is a set of parameter to access an object storage bucket.
 | usePathStyle | Allows you to enable the client to use path-style addressing, i.e., https?://ENDPOINT/BUCKET/KEY. By default, a virtual-host addressing is used (https?://BUCKET.ENDPOINT/KEY). | bool | false |
 | backendType | BackendType is an identifier for the object storage to be used. | string | false |
 | caCert | Path to SSL CA certificate file used in addition to system default. | string | false |
+| noChecksumValidation | NoChecksumValidation disables checksum calculation and validation on S3 requests and responses. Enable this when using an S3-compatible object storage that does not support AWS-style checksum headers (e.g. some on-premises or third-party S3 implementations). By default, the AWS SDK calculates and validates checksums on all supported operations, which ensures data integrity but may be rejected by non-compliant S3 servers. This option has no effect when backendType is set to gcs or azure. | bool | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/docs/crd_mysqlcluster_v1beta2.md
+++ b/docs/crd_mysqlcluster_v1beta2.md
@@ -206,6 +206,7 @@ BucketConfig is a set of parameter to access an object storage bucket.
 | usePathStyle | Allows you to enable the client to use path-style addressing, i.e., https?://ENDPOINT/BUCKET/KEY. By default, a virtual-host addressing is used (https?://BUCKET.ENDPOINT/KEY). | bool | false |
 | backendType | BackendType is an identifier for the object storage to be used. | string | false |
 | caCert | Path to SSL CA certificate file used in addition to system default. | string | false |
+| noChecksumValidation | NoChecksumValidation disables checksum calculation and validation on S3 requests and responses. Enable this when using an S3-compatible object storage that does not support AWS-style checksum headers (e.g. some on-premises or third-party S3 implementations). By default, the AWS SDK calculates and validates checksums on all supported operations, which ensures data integrity but may be rejected by non-compliant S3 servers. This option has no effect when backendType is set to gcs or azure. | bool | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/pkg/bucket/s3.go
+++ b/pkg/bucket/s3.go
@@ -55,6 +55,16 @@ func WithHTTPClient(c *http.Client) func(*s3.Options) {
 	}
 }
 
+// WithNoChecksumValidation disables checksum calculation and validation on S3 requests
+// and responses. Use this for S3-compatible servers that do not support AWS-style
+// checksum headers.
+func WithNoChecksumValidation() func(*s3.Options) {
+	return func(o *s3.Options) {
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired
+	}
+}
+
 type s3Bucket struct {
 	name   string
 	client *s3.Client
@@ -82,10 +92,14 @@ func (b s3Bucket) Put(ctx context.Context, key string, data io.Reader, objectSiz
 		mt = "application/zstd"
 	}
 
+	clientOpts := b.client.Options()
 	uploader := manager.NewUploader(b.client, func(u *manager.Uploader) {
 		u.Concurrency = 1
 		u.LeavePartsOnError = false
 		u.PartSize = decidePartSize(objectSize)
+		if clientOpts.RequestChecksumCalculation == aws.RequestChecksumCalculationWhenRequired {
+			u.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		}
 	})
 	pi := &s3.PutObjectInput{
 		Bucket:      &b.name,


### PR DESCRIPTION
Some S3-compatible object storage servers do not support the AWS-style checksum headers that the AWS SDK v2 now sends by default on all supported operations. This causes backup and restore jobs to fail with HTTP 400 errors against these servers.

Add a noChecksumValidation field to BucketConfig so operators can opt out of checksum calculation and validation when targeting a non-compliant S3 implementation, while keeping the default behaviour (checksums always validated) for standard AWS S3 deployments.