### PR TITLE
Add default container user, remove hard-coded UID/GID injection

### DIFF
--- a/cmd/moco-controller/cmd/root.go
+++ b/cmd/moco-controller/cmd/root.go
@@ -23,25 +23,26 @@ var (
 )
 
 var config struct {
-	metricsAddr                string
-	probeAddr                  string
-	pprofAddr                  string
-	leaderElectionID           string
-	webhookAddr                string
-	certDir                    string
-	grpcCertDir                string
-	agentImage                 string
-	backupImage                string
-	fluentBitImage             string
-	exporterImage              string
-	pvcSyncAnnotationKeys      []string
-	pvcSyncLabelKeys           []string
-	interval                   time.Duration
-	maxConcurrentReconciles    int
-	mySQLConfigMapHistoryLimit int
-	partitionUpdateInterval    time.Duration
-	qps                        int
-	zapOpts                    zap.Options
+	metricsAddr                   string
+	probeAddr                     string
+	pprofAddr                     string
+	leaderElectionID              string
+	webhookAddr                   string
+	certDir                       string
+	grpcCertDir                   string
+	agentImage                    string
+	backupImage                   string
+	fluentBitImage                string
+	exporterImage                 string
+	pvcSyncAnnotationKeys         []string
+	pvcSyncLabelKeys              []string
+	interval                      time.Duration
+	maxConcurrentReconciles       int
+	mySQLConfigMapHistoryLimit    int
+	partitionUpdateInterval       time.Duration
+	qps                           int
+	disableDefaultSecurityContext bool
+	zapOpts                       zap.Options
 }
 
 func init() {
@@ -113,6 +114,7 @@ func init() {
 	fs.IntVar(&config.maxConcurrentReconciles, "max-concurrent-reconciles", 8, "The maximum number of concurrent reconciles which can be run")
 	fs.IntVar(&config.mySQLConfigMapHistoryLimit, "mysql-configmap-history-limit", 10, "The maximum number of MySQLConfigMap's history to be kept")
 	fs.DurationVar(&config.partitionUpdateInterval, "partition-update-interval", 0*time.Millisecond, "The minimum update interval for partitions (e.g., 5s, 100ms)")
+	fs.BoolVar(&config.disableDefaultSecurityContext, "disable-default-security-context", false, "Disable injecting default runAsUser/runAsGroup on managed containers and fsGroup on managed pods. Enable this on platforms such as OpenShift that assign project-scoped UID/GID/fsGroup ranges.")
 	// The default QPS is 20.
 	// https://github.com/kubernetes-sigs/controller-runtime/blob/a26de2d610c3cf4b2a02688534aaf5a65749c743/pkg/client/config/config.go#L84-L85
 	fs.IntVar(&config.qps, "apiserver-qps-throttle", 20, "The maximum QPS to the API server.")

--- a/cmd/moco-controller/cmd/run.go
+++ b/cmd/moco-controller/cmd/run.go
@@ -103,19 +103,20 @@ func subMain(ns, addr string, port int) error {
 	defer clusterMgr.StopAll()
 
 	if err = (&controllers.MySQLClusterReconciler{
-		Client:                     mgr.GetClient(),
-		Scheme:                     mgr.GetScheme(),
-		Recorder:                   mgr.GetEventRecorderFor("moco-controller"),
-		AgentImage:                 config.agentImage,
-		BackupImage:                config.backupImage,
-		FluentBitImage:             config.fluentBitImage,
-		ExporterImage:              config.exporterImage,
-		SystemNamespace:            ns,
-		PVCSyncAnnotationKeys:      config.pvcSyncAnnotationKeys,
-		PVCSyncLabelKeys:           config.pvcSyncLabelKeys,
-		ClusterManager:             clusterMgr,
-		MaxConcurrentReconciles:    config.maxConcurrentReconciles,
-		MySQLConfigMapHistoryLimit: config.mySQLConfigMapHistoryLimit,
+		Client:                        mgr.GetClient(),
+		Scheme:                        mgr.GetScheme(),
+		Recorder:                      mgr.GetEventRecorderFor("moco-controller"),
+		AgentImage:                    config.agentImage,
+		BackupImage:                   config.backupImage,
+		FluentBitImage:                config.fluentBitImage,
+		ExporterImage:                 config.exporterImage,
+		SystemNamespace:               ns,
+		PVCSyncAnnotationKeys:         config.pvcSyncAnnotationKeys,
+		PVCSyncLabelKeys:              config.pvcSyncLabelKeys,
+		ClusterManager:                clusterMgr,
+		MaxConcurrentReconciles:       config.maxConcurrentReconciles,
+		MySQLConfigMapHistoryLimit:    config.mySQLConfigMapHistoryLimit,
+		DisableDefaultSecurityContext: config.disableDefaultSecurityContext,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MySQLCluster")
 		return err

--- a/containers/fluent-bit/Dockerfile
+++ b/containers/fluent-bit/Dockerfile
@@ -72,5 +72,7 @@ COPY --from=builder /fluent-bit /fluent-bit
 
 EXPOSE 2020
 
+USER 10000:10000
+
 ENTRYPOINT ["/fluent-bit/bin/fluent-bit"]
 CMD ["-q", "-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -448,19 +448,6 @@ func (r *MySQLClusterReconciler) updateContainerWithSecurityContext(container *c
 	}
 }
 
-// defaultPodSecurityContext returns the PodSecurityContext applied to MOCO-managed
-// pods. FSGroupChangePolicy is always set to OnRootMismatch. FSGroup is defaulted to
-// constants.ContainerGID unless DisableDefaultSecurityContext is enabled, in which case
-// the platform (e.g. OpenShift SCC) assigns the fsGroup.
-func (r *MySQLClusterReconciler) defaultPodSecurityContext() *corev1ac.PodSecurityContextApplyConfiguration {
-	psc := corev1ac.PodSecurityContext().
-		WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch)
-	if !r.DisableDefaultSecurityContext {
-		psc.WithFSGroup(constants.ContainerGID)
-	}
-	return psc
-}
-
 func updateContainerWithOverwriteContainers(cluster *mocov1beta2.MySQLCluster, container *corev1ac.ContainerApplyConfiguration) {
 	if len(cluster.Spec.PodTemplate.OverwriteContainers) == 0 {
 		return

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -435,13 +435,6 @@ func updateContainerWithSecurityContext(container *corev1ac.ContainerApplyConfig
 	if container.SecurityContext == nil {
 		container.WithSecurityContext(corev1ac.SecurityContext())
 	}
-
-	if container.SecurityContext.RunAsUser == nil {
-		container.SecurityContext.WithRunAsUser(constants.ContainerUID)
-	}
-	if container.SecurityContext.RunAsGroup == nil {
-		container.SecurityContext.WithRunAsGroup(constants.ContainerGID)
-	}
 }
 
 func updateContainerWithOverwriteContainers(cluster *mocov1beta2.MySQLCluster, container *corev1ac.ContainerApplyConfiguration) {

--- a/controllers/mysql_container.go
+++ b/controllers/mysql_container.go
@@ -115,7 +115,7 @@ func (r *MySQLClusterReconciler) makeV1MySQLDContainer(cluster *mocov1beta2.MySQ
 			WithMountPath(constants.MySQLDataPath),
 	)
 
-	updateContainerWithSecurityContext(source)
+	r.updateContainerWithSecurityContext(source)
 
 	return source, nil
 }
@@ -186,7 +186,7 @@ func (r *MySQLClusterReconciler) makeV1AgentContainer(cluster *mocov1beta2.MySQL
 			}),
 	)
 
-	updateContainerWithSecurityContext(c)
+	r.updateContainerWithSecurityContext(c)
 	updateContainerWithOverwriteContainers(cluster, c)
 
 	return c
@@ -227,7 +227,7 @@ func (r *MySQLClusterReconciler) makeV1SlowQueryLogContainer(cluster *mocov1beta
 				}),
 		)
 
-	updateContainerWithSecurityContext(c)
+	r.updateContainerWithSecurityContext(c)
 	updateContainerWithOverwriteContainers(cluster, c)
 
 	return c
@@ -268,7 +268,7 @@ func (r *MySQLClusterReconciler) makeV1ExporterContainer(cluster *mocov1beta2.My
 		c.WithArgs("--collect." + cl)
 	}
 
-	updateContainerWithSecurityContext(c)
+	r.updateContainerWithSecurityContext(c)
 	updateContainerWithOverwriteContainers(cluster, c)
 
 	return c
@@ -284,7 +284,7 @@ func (r *MySQLClusterReconciler) makeV1OptionalContainers(cluster *mocov1beta2.M
 			continue
 		}
 
-		updateContainerWithSecurityContext(&c)
+		r.updateContainerWithSecurityContext(&c)
 
 		switch *c.Name {
 		case constants.MysqldContainerName:
@@ -317,7 +317,7 @@ func (r *MySQLClusterReconciler) makeV1InitContainer(ctx context.Context, cluste
 	spec := cluster.Spec.PodTemplate.Spec.DeepCopy()
 	for _, given := range spec.InitContainers {
 		ic := given
-		updateContainerWithSecurityContext(&ic)
+		r.updateContainerWithSecurityContext(&ic)
 		initContainers = append(initContainers, &ic)
 	}
 	return initContainers, nil
@@ -383,7 +383,7 @@ func (r *MySQLClusterReconciler) makeMocoInitContainer(ctx context.Context, clus
 		c.WithArgs(fmt.Sprintf("%s=%s", constants.MocoInitLowerCaseTableNamesFlag, v))
 	}
 
-	updateContainerWithSecurityContext(c)
+	r.updateContainerWithSecurityContext(c)
 	updateContainerWithOverwriteContainers(cluster, c)
 
 	return c, nil
@@ -411,7 +411,7 @@ func (r *MySQLClusterReconciler) makeInitContainerWithCopyMocoInitBin(cluster *m
 			WithName(constants.SharedVolumeName).
 			WithMountPath(constants.SharedPath))
 
-	updateContainerWithSecurityContext(c)
+	r.updateContainerWithSecurityContext(c)
 	updateContainerWithOverwriteContainers(cluster, c)
 
 	return c
@@ -431,10 +431,34 @@ func (r *MySQLClusterReconciler) getEnableLowerCaseTableNamesFromConf(ctx contex
 	return v, ok, nil
 }
 
-func updateContainerWithSecurityContext(container *corev1ac.ContainerApplyConfiguration) {
+func (r *MySQLClusterReconciler) updateContainerWithSecurityContext(container *corev1ac.ContainerApplyConfiguration) {
 	if container.SecurityContext == nil {
 		container.WithSecurityContext(corev1ac.SecurityContext())
 	}
+
+	if r.DisableDefaultSecurityContext {
+		return
+	}
+
+	if container.SecurityContext.RunAsUser == nil {
+		container.SecurityContext.WithRunAsUser(constants.ContainerUID)
+	}
+	if container.SecurityContext.RunAsGroup == nil {
+		container.SecurityContext.WithRunAsGroup(constants.ContainerGID)
+	}
+}
+
+// defaultPodSecurityContext returns the PodSecurityContext applied to MOCO-managed
+// pods. FSGroupChangePolicy is always set to OnRootMismatch. FSGroup is defaulted to
+// constants.ContainerGID unless DisableDefaultSecurityContext is enabled, in which case
+// the platform (e.g. OpenShift SCC) assigns the fsGroup.
+func (r *MySQLClusterReconciler) defaultPodSecurityContext() *corev1ac.PodSecurityContextApplyConfiguration {
+	psc := corev1ac.PodSecurityContext().
+		WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch)
+	if !r.DisableDefaultSecurityContext {
+		psc.WithFSGroup(constants.ContainerGID)
+	}
+	return psc
 }
 
 func updateContainerWithOverwriteContainers(cluster *mocov1beta2.MySQLCluster, container *corev1ac.ContainerApplyConfiguration) {

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -123,18 +123,19 @@ func apply[S any, T clientObjectConstraint[S], U runtime.ApplyConfiguration](ctx
 // MySQLClusterReconciler reconciles a MySQLCluster object
 type MySQLClusterReconciler struct {
 	client.Client
-	Scheme                     *runtime.Scheme
-	Recorder                   record.EventRecorder
-	AgentImage                 string
-	BackupImage                string
-	FluentBitImage             string
-	ExporterImage              string
-	SystemNamespace            string
-	PVCSyncAnnotationKeys      []string
-	PVCSyncLabelKeys           []string
-	ClusterManager             clustering.ClusterManager
-	MaxConcurrentReconciles    int
-	MySQLConfigMapHistoryLimit int
+	Scheme                        *runtime.Scheme
+	Recorder                      record.EventRecorder
+	AgentImage                    string
+	BackupImage                   string
+	FluentBitImage                string
+	ExporterImage                 string
+	SystemNamespace               string
+	PVCSyncAnnotationKeys         []string
+	PVCSyncLabelKeys              []string
+	ClusterManager                clustering.ClusterManager
+	MaxConcurrentReconciles       int
+	MySQLConfigMapHistoryLimit    int
+	DisableDefaultSecurityContext bool
 }
 
 //+kubebuilder:rbac:groups=moco.cybozu.com,resources=mysqlclusters,verbs=get;list;watch;update;patch
@@ -910,6 +911,9 @@ func (r *MySQLClusterReconciler) reconcileV1StatefulSet(ctx context.Context, clu
 	if podSpec.SecurityContext == nil {
 		podSpec.WithSecurityContext(corev1ac.PodSecurityContext())
 	}
+	if !r.DisableDefaultSecurityContext && podSpec.SecurityContext.FSGroup == nil {
+		podSpec.SecurityContext.WithFSGroup(constants.ContainerGID)
+	}
 	if podSpec.SecurityContext.FSGroupChangePolicy == nil {
 		podSpec.SecurityContext.WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch)
 	}
@@ -1233,7 +1237,7 @@ func (r *MySQLClusterReconciler) reconcileV1BackupJob(ctx context.Context, clust
 		WithSecurityContext(corev1ac.SecurityContext().WithReadOnlyRootFilesystem(true)).
 		WithResources(resources)
 
-	updateContainerWithSecurityContext(container)
+	r.updateContainerWithSecurityContext(container)
 
 	cronJobName := cluster.BackupCronJobName()
 	cronJob := batchv1ac.CronJob(cronJobName, cluster.Namespace).
@@ -1262,9 +1266,7 @@ func (r *MySQLClusterReconciler) reconcileV1BackupJob(ctx context.Context, clust
 								return volumes
 							}()...).
 							WithContainers(container).
-							WithSecurityContext(corev1ac.PodSecurityContext().
-								WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch),
-							),
+							WithSecurityContext(r.defaultPodSecurityContext()),
 						),
 					),
 				),
@@ -1566,9 +1568,7 @@ func (r *MySQLClusterReconciler) reconcileV1RestoreJob(ctx context.Context, clus
 							return volumes
 						}()...).
 						WithContainers(container).
-						WithSecurityContext(corev1ac.PodSecurityContext().
-							WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch),
-						),
+						WithSecurityContext(r.defaultPodSecurityContext()),
 					),
 				),
 			)
@@ -1930,6 +1930,7 @@ func setControllerReferenceWithPVC(cluster *mocov1beta2.MySQLCluster, pvc *corev
 		WithKind(gvk.Kind).
 		WithName(cluster.Name).
 		WithUID(cluster.GetUID()).
+		WithBlockOwnerDeletion(true).
 		WithController(true))
 
 	return nil

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -1612,6 +1612,19 @@ func (r *MySQLClusterReconciler) reconcileV1RestoreJob(ctx context.Context, clus
 	return nil
 }
 
+// defaultPodSecurityContext returns the PodSecurityContext applied to MOCO-managed
+// pods. FSGroupChangePolicy is always set to OnRootMismatch. FSGroup is defaulted to
+// constants.ContainerGID unless DisableDefaultSecurityContext is enabled, in which case
+// the platform (e.g. OpenShift SCC) assigns the fsGroup.
+func (r *MySQLClusterReconciler) defaultPodSecurityContext() *corev1ac.PodSecurityContextApplyConfiguration {
+	psc := corev1ac.PodSecurityContext().
+		WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch)
+	if !r.DisableDefaultSecurityContext {
+		psc.WithFSGroup(constants.ContainerGID)
+	}
+	return psc
+}
+
 func (r *MySQLClusterReconciler) reconcileV1RestoreJobRole(ctx context.Context, cluster *mocov1beta2.MySQLCluster) error {
 	log := crlog.FromContext(ctx)
 

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -1930,7 +1930,6 @@ func setControllerReferenceWithPVC(cluster *mocov1beta2.MySQLCluster, pvc *corev
 		WithKind(gvk.Kind).
 		WithName(cluster.Name).
 		WithUID(cluster.GetUID()).
-		WithBlockOwnerDeletion(true).
 		WithController(true))
 
 	return nil

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -910,9 +910,6 @@ func (r *MySQLClusterReconciler) reconcileV1StatefulSet(ctx context.Context, clu
 	if podSpec.SecurityContext == nil {
 		podSpec.WithSecurityContext(corev1ac.PodSecurityContext())
 	}
-	if podSpec.SecurityContext.FSGroup == nil {
-		podSpec.SecurityContext.WithFSGroup(constants.ContainerGID)
-	}
 	if podSpec.SecurityContext.FSGroupChangePolicy == nil {
 		podSpec.SecurityContext.WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch)
 	}
@@ -1266,7 +1263,6 @@ func (r *MySQLClusterReconciler) reconcileV1BackupJob(ctx context.Context, clust
 							}()...).
 							WithContainers(container).
 							WithSecurityContext(corev1ac.PodSecurityContext().
-								WithFSGroup(constants.ContainerGID).
 								WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch),
 							),
 						),
@@ -1571,7 +1567,6 @@ func (r *MySQLClusterReconciler) reconcileV1RestoreJob(ctx context.Context, clus
 						}()...).
 						WithContainers(container).
 						WithSecurityContext(corev1ac.PodSecurityContext().
-							WithFSGroup(constants.ContainerGID).
 							WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch),
 						),
 					),

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -971,7 +971,7 @@ dummyKey: dummyValue
 		Expect(sts.Spec.Template.Spec.TerminationGracePeriodSeconds).NotTo(BeNil())
 		Expect(*sts.Spec.Template.Spec.TerminationGracePeriodSeconds).To(BeNumerically("==", defaultTerminationGracePeriodSeconds))
 		Expect(sts.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
-		Expect(sts.Spec.Template.Spec.SecurityContext.FSGroup).To(BeNil())
+		Expect(*sts.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(int64(constants.ContainerGID)))
 		Expect(*sts.Spec.Template.Spec.SecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
 		Expect(sts.Spec.Template.Spec.Affinity).NotTo(BeNil())
 		Expect(sts.Spec.Template.Spec.Affinity.PodAntiAffinity).NotTo(BeNil())
@@ -984,8 +984,10 @@ dummyKey: dummyValue
 		foundExporter := false
 		for _, c := range sts.Spec.Template.Spec.Containers {
 			Expect(c.SecurityContext).NotTo(BeNil())
-			Expect(c.SecurityContext.RunAsUser).To(BeNil())
-			Expect(c.SecurityContext.RunAsGroup).To(BeNil())
+			Expect(c.SecurityContext.RunAsUser).NotTo(BeNil())
+			Expect(*c.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
+			Expect(c.SecurityContext.RunAsGroup).NotTo(BeNil())
+			Expect(*c.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerGID)))
 			switch c.Name {
 			case constants.MysqldContainerName:
 				foundMysqld = true
@@ -1022,8 +1024,10 @@ dummyKey: dummyValue
 		Expect(cpInitContainer.Image).To(Equal(testAgentImage))
 		Expect(cpInitContainer.Command).To(ContainElement("cp"))
 		Expect(cpInitContainer.SecurityContext).NotTo(BeNil())
-		Expect(cpInitContainer.SecurityContext.RunAsUser).To(BeNil())
-		Expect(cpInitContainer.SecurityContext.RunAsGroup).To(BeNil())
+		Expect(cpInitContainer.SecurityContext.RunAsUser).NotTo(BeNil())
+		Expect(*cpInitContainer.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
+		Expect(cpInitContainer.SecurityContext.RunAsGroup).NotTo(BeNil())
+		Expect(*cpInitContainer.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerGID)))
 
 		initContainer := &sts.Spec.Template.Spec.InitContainers[1]
 		Expect(initContainer.Name).To(Equal(constants.InitContainerName))
@@ -1032,8 +1036,10 @@ dummyKey: dummyValue
 		Expect(initContainer.Resources.Requests).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("512Mi")}))
 		Expect(initContainer.Resources.Limits).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("512Mi")}))
 		Expect(initContainer.SecurityContext).NotTo(BeNil())
-		Expect(initContainer.SecurityContext.RunAsUser).To(BeNil())
-		Expect(initContainer.SecurityContext.RunAsGroup).To(BeNil())
+		Expect(initContainer.SecurityContext.RunAsUser).NotTo(BeNil())
+		Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
+		Expect(initContainer.SecurityContext.RunAsGroup).NotTo(BeNil())
+		Expect(*initContainer.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerGID)))
 
 		Expect(sts.Spec.VolumeClaimTemplates).To(HaveLen(1))
 		Expect(sts.Spec.VolumeClaimTemplates[0].Name).To(Equal(constants.MySQLDataVolumeName))
@@ -1239,8 +1245,10 @@ dummyKey: dummyValue
 				Expect(c.LivenessProbe.TerminationGracePeriodSeconds).To(Equal(new(int64(200))))
 				Expect(c.SecurityContext.ReadOnlyRootFilesystem).NotTo(BeNil())
 				Expect(*c.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
-				Expect(c.SecurityContext.RunAsUser).To(BeNil())
-				Expect(c.SecurityContext.RunAsGroup).To(BeNil())
+				Expect(c.SecurityContext.RunAsUser).NotTo(BeNil())
+				Expect(*c.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
+				Expect(c.SecurityContext.RunAsGroup).NotTo(BeNil())
+				Expect(*c.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerUID)))
 			case constants.AgentContainerName:
 				Expect(c.Args).To(ContainElement("20s"))
 				Expect(c.Args).To(ContainElement("0 * * * *"))
@@ -1264,8 +1272,10 @@ dummyKey: dummyValue
 				foundDummyContainer = true
 				Expect(c.Image).To(Equal("dummy:latest"))
 				Expect(c.SecurityContext.ReadOnlyRootFilesystem).To(BeNil())
-				Expect(c.SecurityContext.RunAsUser).To(BeNil())
-				Expect(c.SecurityContext.RunAsGroup).To(BeNil())
+				Expect(c.SecurityContext.RunAsUser).NotTo(BeNil())
+				Expect(*c.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
+				Expect(c.SecurityContext.RunAsGroup).NotTo(BeNil())
+				Expect(*c.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerUID)))
 			}
 		}
 		Expect(foundExporter).To(BeTrue())

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -984,10 +984,8 @@ dummyKey: dummyValue
 		foundExporter := false
 		for _, c := range sts.Spec.Template.Spec.Containers {
 			Expect(c.SecurityContext).NotTo(BeNil())
-			Expect(c.SecurityContext.RunAsUser).NotTo(BeNil())
-			Expect(*c.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
-			Expect(c.SecurityContext.RunAsGroup).NotTo(BeNil())
-			Expect(*c.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerGID)))
+			Expect(c.SecurityContext.RunAsUser).To(BeNil())
+			Expect(c.SecurityContext.RunAsGroup).To(BeNil())
 			switch c.Name {
 			case constants.MysqldContainerName:
 				foundMysqld = true
@@ -1024,10 +1022,8 @@ dummyKey: dummyValue
 		Expect(cpInitContainer.Image).To(Equal(testAgentImage))
 		Expect(cpInitContainer.Command).To(ContainElement("cp"))
 		Expect(cpInitContainer.SecurityContext).NotTo(BeNil())
-		Expect(cpInitContainer.SecurityContext.RunAsUser).NotTo(BeNil())
-		Expect(*cpInitContainer.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
-		Expect(cpInitContainer.SecurityContext.RunAsGroup).NotTo(BeNil())
-		Expect(*cpInitContainer.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerGID)))
+		Expect(cpInitContainer.SecurityContext.RunAsUser).To(BeNil())
+		Expect(cpInitContainer.SecurityContext.RunAsGroup).To(BeNil())
 
 		initContainer := &sts.Spec.Template.Spec.InitContainers[1]
 		Expect(initContainer.Name).To(Equal(constants.InitContainerName))
@@ -1036,10 +1032,8 @@ dummyKey: dummyValue
 		Expect(initContainer.Resources.Requests).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("512Mi")}))
 		Expect(initContainer.Resources.Limits).To(Equal(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("512Mi")}))
 		Expect(initContainer.SecurityContext).NotTo(BeNil())
-		Expect(initContainer.SecurityContext.RunAsUser).NotTo(BeNil())
-		Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
-		Expect(initContainer.SecurityContext.RunAsGroup).NotTo(BeNil())
-		Expect(*initContainer.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerGID)))
+		Expect(initContainer.SecurityContext.RunAsUser).To(BeNil())
+		Expect(initContainer.SecurityContext.RunAsGroup).To(BeNil())
 
 		Expect(sts.Spec.VolumeClaimTemplates).To(HaveLen(1))
 		Expect(sts.Spec.VolumeClaimTemplates[0].Name).To(Equal(constants.MySQLDataVolumeName))
@@ -1245,10 +1239,8 @@ dummyKey: dummyValue
 				Expect(c.LivenessProbe.TerminationGracePeriodSeconds).To(Equal(new(int64(200))))
 				Expect(c.SecurityContext.ReadOnlyRootFilesystem).NotTo(BeNil())
 				Expect(*c.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
-				Expect(c.SecurityContext.RunAsUser).NotTo(BeNil())
-				Expect(*c.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
-				Expect(c.SecurityContext.RunAsGroup).NotTo(BeNil())
-				Expect(*c.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerUID)))
+				Expect(c.SecurityContext.RunAsUser).To(BeNil())
+				Expect(c.SecurityContext.RunAsGroup).To(BeNil())
 			case constants.AgentContainerName:
 				Expect(c.Args).To(ContainElement("20s"))
 				Expect(c.Args).To(ContainElement("0 * * * *"))
@@ -1272,10 +1264,8 @@ dummyKey: dummyValue
 				foundDummyContainer = true
 				Expect(c.Image).To(Equal("dummy:latest"))
 				Expect(c.SecurityContext.ReadOnlyRootFilesystem).To(BeNil())
-				Expect(c.SecurityContext.RunAsUser).NotTo(BeNil())
-				Expect(*c.SecurityContext.RunAsUser).To(Equal(int64(constants.ContainerUID)))
-				Expect(c.SecurityContext.RunAsGroup).NotTo(BeNil())
-				Expect(*c.SecurityContext.RunAsGroup).To(Equal(int64(constants.ContainerUID)))
+				Expect(c.SecurityContext.RunAsUser).To(BeNil())
+				Expect(c.SecurityContext.RunAsGroup).To(BeNil())
 			}
 		}
 		Expect(foundExporter).To(BeTrue())

--- a/controllers/mysqlcluster_controller_test.go
+++ b/controllers/mysqlcluster_controller_test.go
@@ -971,7 +971,7 @@ dummyKey: dummyValue
 		Expect(sts.Spec.Template.Spec.TerminationGracePeriodSeconds).NotTo(BeNil())
 		Expect(*sts.Spec.Template.Spec.TerminationGracePeriodSeconds).To(BeNumerically("==", defaultTerminationGracePeriodSeconds))
 		Expect(sts.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
-		Expect(*sts.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(int64(constants.ContainerGID)))
+		Expect(sts.Spec.Template.Spec.SecurityContext.FSGroup).To(BeNil())
 		Expect(*sts.Spec.Template.Spec.SecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
 		Expect(sts.Spec.Template.Spec.Affinity).NotTo(BeNil())
 		Expect(sts.Spec.Template.Spec.Affinity.PodAntiAffinity).NotTo(BeNil())

--- a/docs/moco-controller.md
+++ b/docs/moco-controller.md
@@ -19,6 +19,7 @@ Flags:
       --backup-image string                 The image of moco-backup container (default "ghcr.io/cybozu-go/moco-backup:0.23.2")
       --cert-dir string                     webhook certificate directory
       --check-interval duration             Interval of cluster maintenance (default 1m0s)
+      --disable-default-security-context    Disable injecting default runAsUser/runAsGroup on managed containers and fsGroup on managed pods. Enable this on platforms such as OpenShift that assign project-scoped UID/GID/fsGroup ranges.
       --fluent-bit-image string             The image of fluent-bit sidecar container (default "ghcr.io/cybozu-go/moco/fluent-bit:3.0.2.1")
       --grpc-cert-dir string                gRPC certificate directory (default "/grpc-cert")
       --health-probe-addr string            Listen address for health probes (default ":8081")


### PR DESCRIPTION
## Summary

This change makes MOCO compatible with restrictive Pod Security admission, in particular OpenShift's `restricted-v2` SCC, by:

1. Ensuring every container image MOCO ships declares a non-root `USER` so the operator does not need to inject UIDs.
2. Allowing operators to opt out of MOCO's default injection of `runAsUser` / `runAsGroup` (on managed containers) and `fsGroup` (on managed pods) via a new command-line flag, so OpenShift can assign its project-scoped UID / GID / fsGroup ranges.

Restrictive SCCs assign project-scoped UID / GID / fsGroup ranges and reject pods that pin those fields to a fixed value. By default MOCO still injects its historical UID/GID/fsGroup values, so existing installations are unaffected; OpenShift users enable the new flag to let the platform assign these values instead.

Non-rootness is preserved by ensuring every container image MOCO ships already declares a non-root `USER` in its Dockerfile. The `mysql`, `mysqld_exporter`, and `moco-agent` images already do this; this PR adds the missing `USER 10000:10000` to `fluent-bit`.

Users who need a specific UID/GID/fsGroup can still set it explicitly via `PodTemplate.Spec.Containers[*].SecurityContext` or `PodTemplate.Spec.SecurityContext` on the `MySQLCluster` resource (cf. #777, which made per-container `SecurityContext` overridable).

## Related issues

- Relates to #389 — *Cannot set blockOwnerDeletion* (PVC creation forbidden on OpenShift). This PR no longer changes `blockOwnerDeletion`; see "Out of scope" below.
- Builds on #777 — overrides for container `SecurityContext` are how users opt back in to specific UID/GID values when needed.

## Changes

- **`containers/fluent-bit/Dockerfile`** — add `USER 10000:10000` so the fluent-bit sidecar runs as non-root without operator-injected UIDs.
- **`cmd/moco-controller/cmd/root.go`** — add a new `--disable-default-security-context` flag (default `false`).
- **`cmd/moco-controller/cmd/run.go`** — wire the flag into `MySQLClusterReconciler`.
- **`controllers/mysqlcluster_controller.go`**
  - Add a `DisableDefaultSecurityContext` field to `MySQLClusterReconciler`.
  - When the flag is **disabled** (default), behavior is unchanged: managed containers get `RunAsUser`/`RunAsGroup` and managed pods (StatefulSet, backup `Job`, restore `Job`) get `FSGroup` defaulted to `constants.ContainerUID`/`ContainerGID`. `FSGroupChangePolicy=OnRootMismatch` is always retained.
  - When the flag is **enabled**, MOCO no longer injects `RunAsUser`/`RunAsGroup`/`FSGroup`, leaving those fields for the platform (e.g. OpenShift SCC) to assign.
- **`controllers/mysql_container.go`** — `updateContainerWithSecurityContext` is now a reconciler method that honors the flag, and a `defaultPodSecurityContext()` helper centralizes the pod-level defaulting.
- **`docs/moco-controller.md`** — document the new flag.

## Out of scope

The original draft of this PR also dropped `blockOwnerDeletion` from the PVC owner reference to work around the OpenShift `OwnerReferencesPermissionEnforcement` admission check (#389). Per maintainer feedback, that behavior is preserved here and the underlying issue will be addressed separately (likely via a finalizer-based approach). For now, OpenShift/OKD users can apply the RBAC workaround described in #389 (granting `update` on `mysqlclusters/finalizers` to the `statefulset-controller` service account).

## Compatibility

No CRD or API changes. With the flag at its default (`false`), generated pod and container `SecurityContext` are identical to before this PR, so existing deployments are unaffected. On OpenShift, setting `--disable-default-security-context` lets the SCC admit the pod and assign project-scoped UID and fsGroup values; non-rootness is still guaranteed by the images' `USER` directives.

Helm users can enable the flag via `extraArgs: ["--disable-default-security-context"]`.