### PR TITLE
Add predicates to PodWatcher for better event filtering

### DIFF
--- a/controllers/partition_controller.go
+++ b/controllers/partition_controller.go
@@ -21,7 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -121,8 +120,7 @@ func (r *StatefulSetPartitionReconciler) SetupWithManager(mgr ctrl.Manager) erro
 
 // partitionControllerPredicate filters StatefulSets and Pods managed by MOCO.
 func partitionControllerPredicate() predicate.Funcs {
-	// Predicate function for StatefulSets and Pods. They have a prefixed name and specific labels.
-	prctFunc := func(o client.Object) bool {
+	return predicate.NewPredicateFuncs(func(o client.Object) bool {
 		if !strings.HasPrefix(o.GetName(), "moco-") {
 			return false
 		}
@@ -135,14 +133,7 @@ func partitionControllerPredicate() predicate.Funcs {
 			return false
 		}
 		return true
-	}
-
-	return predicate.Funcs{
-		UpdateFunc:  func(e event.UpdateEvent) bool { return prctFunc(e.ObjectNew) },
-		CreateFunc:  func(e event.CreateEvent) bool { return prctFunc(e.Object) },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return prctFunc(e.Object) },
-		GenericFunc: func(e event.GenericEvent) bool { return prctFunc(e.Object) },
-	}
+	})
 }
 
 // isRolloutReady returns true if the StatefulSet is ready for rolling update.

--- a/controllers/partition_controller.go
+++ b/controllers/partition_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -106,34 +105,28 @@ func (r *StatefulSetPartitionReconciler) Reconcile(ctx context.Context, req reco
 }
 
 func (r *StatefulSetPartitionReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	stsPrct := partitionControllerPredicate()
-	podPrct := partitionControllerPredicate()
+	pred := partitionControllerPredicate()
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appsv1.StatefulSet{}, builder.WithPredicates(stsPrct)).
-		Owns(&corev1.Pod{}, builder.WithPredicates(podPrct)).
+		For(&appsv1.StatefulSet{}, builder.WithPredicates(pred)).
+		Owns(&corev1.Pod{}, builder.WithPredicates(pred)).
 		WithOptions(
 			controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles},
 		).
 		Complete(r)
 }
 
-// partitionControllerPredicate filters StatefulSets and Pods managed by MOCO.
-func partitionControllerPredicate() predicate.Funcs {
-	return predicate.NewPredicateFuncs(func(o client.Object) bool {
-		if !strings.HasPrefix(o.GetName(), "moco-") {
-			return false
-		}
-
-		labels := o.GetLabels()
-		if labels[constants.LabelAppName] != constants.AppNameMySQL {
-			return false
-		}
-		if labels[constants.LabelAppCreatedBy] != constants.AppCreator {
-			return false
-		}
-		return true
+func partitionControllerPredicate() predicate.Predicate {
+	pred, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			constants.LabelAppName:      constants.AppNameMySQL,
+			constants.LabelAppCreatedBy: constants.AppCreator,
+		},
 	})
+	if err != nil {
+		panic(err)
+	}
+	return pred
 }
 
 // isRolloutReady returns true if the StatefulSet is ready for rolling update.

--- a/controllers/partition_controller_test.go
+++ b/controllers/partition_controller_test.go
@@ -383,13 +383,6 @@ var _ = Describe("StatefulSetPartitionReconciler predicates", func() {
 				constants.LabelAppCreatedBy: constants.AppCreator,
 			},
 		}}, true),
-		Entry("statefulset without prefix", &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-			Labels: map[string]string{
-				constants.LabelAppName:      constants.AppNameMySQL,
-				constants.LabelAppCreatedBy: constants.AppCreator,
-			},
-		}}, false),
 		Entry("statefulset without app label", &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
 			Name: "moco-test",
 			Labels: map[string]string{

--- a/controllers/pod_watcher.go
+++ b/controllers/pod_watcher.go
@@ -83,23 +83,20 @@ func (r *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
-func podWatcherPredicate() predicate.Funcs {
-	return predicate.NewPredicateFuncs(func(o client.Object) bool {
-		labels := o.GetLabels()
-		if labels[constants.LabelAppName] != constants.AppNameMySQL {
-			return false
-		}
-		if labels[constants.LabelAppCreatedBy] != constants.AppCreator {
-			return false
-		}
-		return true
-	})
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *PodWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	podWatcherPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			constants.LabelAppName:      constants.AppNameMySQL,
+			constants.LabelAppCreatedBy: constants.AppCreator,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Pod{}, builder.WithPredicates(podWatcherPredicate())).
+		For(&corev1.Pod{}, builder.WithPredicates(podWatcherPredicate)).
 		WithOptions(
 			controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles},
 		).

--- a/controllers/pod_watcher.go
+++ b/controllers/pod_watcher.go
@@ -12,9 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // PodWatcher watches MySQL pods and informs the cluster manager of the event.
@@ -81,10 +83,23 @@ func (r *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
+func podWatcherPredicate() predicate.Funcs {
+	return predicate.NewPredicateFuncs(func(o client.Object) bool {
+		labels := o.GetLabels()
+		if labels[constants.LabelAppName] != constants.AppNameMySQL {
+			return false
+		}
+		if labels[constants.LabelAppCreatedBy] != constants.AppCreator {
+			return false
+		}
+		return true
+	})
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *PodWatcher) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Pod{}).
+		For(&corev1.Pod{}, builder.WithPredicates(podWatcherPredicate())).
 		WithOptions(
 			controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles},
 		).

--- a/controllers/pod_watcher_test.go
+++ b/controllers/pod_watcher_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mocov1beta2 "github.com/cybozu-go/moco/api/v1beta2"
+	"github.com/cybozu-go/moco/pkg/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,6 +33,10 @@ func testNewSts(ns string) *appsv1.StatefulSet {
 
 func testNewPod(ns string, name string) *corev1.Pod {
 	pod := &corev1.Pod{}
+	pod.SetLabels(map[string]string{
+		constants.LabelAppName:      constants.AppNameMySQL,
+		constants.LabelAppCreatedBy: constants.AppCreator,
+	})
 	pod.Namespace = ns
 	pod.Name = name
 	pod.Spec.Containers = []corev1.Container{{Name: "mysqld", Image: "moco-mysql:latest"}}


### PR DESCRIPTION
## Summary
This change reduces unnecessary controller reconciliations by filtering out unrelated Pods earlier. It keeps the existing behavior for MOCO-managed Pods, but avoids processing Pods that do not match the expected labels.

## Context
Before this change, the controllers could receive more events than needed and then reject them during reconciliation. That added extra work and made the watch path less efficient. The goal here is to filter events as early as possible while keeping the same ownership checks in the reconcile logic.

## Implementation
`PodWatcher` now uses a predicate so it only watches Pods with the MOCO MySQL labels.

## Note
`StatefulSetPartitionReconciler` uses the same style of predicate for StatefulSets and owned Pods, replacing the older event-specific predicate code with a simpler object-level check using [NewPredicateFuncs](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/predicate#NewPredicateFuncs).
