### PR TITLE
Fix: PVC resize reconciliation fails when an external controller expands the PVC beyond the StatefulSet template size

### DIFF
--- a/.claude/rules/markdown.instructions.md
+++ b/.claude/rules/markdown.instructions.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "**/*.md"
+---
+
+When writing in English in Markdown files, use CEFR B2-level language: be clear and direct, use common vocabulary, and avoid unnecessarily complex sentence structures.

--- a/.github/instructions/focused-tests.instructions.md
+++ b/.github/instructions/focused-tests.instructions.md
@@ -34,3 +34,14 @@ Only use raw `go test` for a quick diagnostic. For envtest packages, carry over 
 ENVTEST_KUBERNETES_VERSION=1.35.0 ENVTEST_ASSETS_DIR="$PWD/bin" \
   go test ./controllers -run TestAPIs -ginkgo.focus 'part of spec name'
 ```
+
+## Standard Go tests in envtest packages
+
+`FOCUS` is passed to `-ginkgo.focus`; it filters Ginkgo specs only. It does not select a top-level standard-library test declared as `func TestXxx(t *testing.T)`. Do not use `make controller-envtest FOCUS='TestReconcilePVC'` as a focused command for such a test.
+
+For a quick diagnostic of a standard Go test in `controllers`, use an exact `-run` expression so that `TestAPIs` is excluded and envtest is not started:
+
+```sh
+go test ./controllers -run '^TestReconcilePVC$' -count=1
+```
+

--- a/.github/instructions/focused-tests.instructions.md
+++ b/.github/instructions/focused-tests.instructions.md
@@ -44,4 +44,3 @@ For a quick diagnostic of a standard Go test in `controllers`, use an exact `-ru
 ```sh
 go test ./controllers -run '^TestReconcilePVC$' -count=1
 ```
-

--- a/.github/skills/table-driven-aaa-tests/SKILL.md
+++ b/.github/skills/table-driven-aaa-tests/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: table-driven-aaa-tests
+description: 'Refactor or implement Go table-driven tests using case-specific Arrange and Assert functions with one shared Act. Use when consolidating duplicated tests, fake-client fixtures, setup helpers, resource builders, expected-state checks, or subtests while preserving behavior and coverage.'
+argument-hint: 'Describe the Go test file or test cases to refactor'
+---
+
+# Table-Driven Arrange/Act/Assert Tests
+
+Use this workflow to structure Go tests so each table entry owns its initial state and expected outcome while the test loop owns one common operation under test.
+
+## Target Shape
+
+```go
+testCases := []struct {
+    name        string
+    arrangeFunc func(*testing.T, Dependency)
+    assertFunc  func(*testing.T, Dependency)
+}{
+    {
+        name: "scenario",
+        arrangeFunc: func(t *testing.T, dependency Dependency) {
+            // Create this case's initial state.
+        },
+        assertFunc: func(t *testing.T, dependency Dependency) {
+            // Read and verify this case's resulting state.
+        },
+    },
+}
+
+for _, tt := range testCases {
+    t.Run(tt.name, func(t *testing.T) {
+        dependency := newDependency(t)
+        tt.arrangeFunc(t, dependency)
+
+        subject := loadSubject(t, dependency)
+        if err := act(t.Context(), dependency, subject); err != nil {
+            t.Fatalf("act failed: %v", err)
+        }
+
+        tt.assertFunc(t, dependency)
+    })
+}
+```
+
+Adapt the fields for per-case identifiers, expected errors, metrics, events, or configuration. Keep the operation being tested in the common loop.
+
+## Recommended
+
+### Define Case Responsibilities
+
+Use fields similar to:
+
+```go
+struct {
+    name        string
+    subjectName string
+    arrangeFunc func(*testing.T, Dependency)
+    assertFunc  func(*testing.T, Dependency)
+    wantErr     string
+    wantMetrics string
+}
+```
+
+- `arrangeFunc` creates all case-specific resources and initial values.
+- `assertFunc` reloads results and performs case-specific checks.
+- Expected errors or optional side effects remain fields when their checking logic is common.
+- Do not keep parallel `wantX` fields if only one case-specific assertion closure consumes them more clearly.
+
+### Build Fresh Common Infrastructure
+
+Inside each `t.Run`:
+
+- create a fresh scheme, fake client, database, registry, clock, or other mutable dependency
+- register common types or common resources
+- run `arrangeFunc`
+- reload the subject from the dependency when persistence is part of the contract
+- construct the reconciler or service with common configuration
+
+Fresh dependencies prevent state and metrics from leaking between subtests. Move genuinely invariant setup into the common loop; leave resources whose values define a scenario in its Arrange closure.
+
+### Extract Narrow Helpers
+
+Create helpers only for repeated mechanical work, such as:
+
+- building resource objects
+- deriving child objects from templates
+- creating a list of objects in a fake client
+- loading and comparing one resource
+- returning a fresh expected label or annotation map
+
+Helpers should expose the arranged state instead of hiding an entire scenario. Prefer:
+
+```go
+objects := newObjectsForStatefulSet(cluster, statefulSet, sizes)
+createObjects(t, client, objects...)
+```
+
+over a helper that silently creates the scheme, client, all resources, and scenario-specific overrides before returning only the client.

--- a/.github/skills/table-driven-aaa-tests/SKILL.md
+++ b/.github/skills/table-driven-aaa-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: table-driven-aaa-tests
-description: 'Refactor or implement Go standard-library TestXxx table-driven tests when Arrange or Assert varies by case, using case-specific functions and one shared Act. Use for duplicated tests, fake-client fixtures, setup helpers, resource builders, or expected-state checks. Do not use for Ginkgo specs or tables with common Arrange and Assert logic.'
+description: 'Implement or refactor Go standard-library TestXxx table-driven tests when Arrange or Assert varies by case, using case-specific functions and one shared Act. Do not use for Ginkgo specs or tables with common Arrange and Assert logic.'
 argument-hint: 'Describe the Go test file or test cases to refactor'
 ---
 
@@ -10,7 +10,7 @@ Use this workflow only for Go standard-library tests declared as `func TestXxx(t
 
 ## Choose the Test Shape
 
-- Use case-specific `arrangeFunc` and `assertFunc` when Arrange or Assert behavior varies between test cases. Once this pattern is selected, define both functions for every case.
+- Use case-specific `arrangeFunc` and `assertFunc` when Arrange or Assert behavior varies between test cases.
 - Keep setup and assertions that every case needs directly in the `t.Run` body. Do not repeat common work in case functions.
 - When Arrange and Assert are both common, write a conventional table-driven test. Put inputs, options, and expected values in fields such as `input`, `want`, or `wantErr`, and keep the shared Arrange and Assert logic in the test loop.
 
@@ -78,7 +78,6 @@ struct {
 Inside each `t.Run`:
 
 - create a fresh scheme, fake client, database, registry, clock, or other mutable dependency
-- register common types or common resources
 - run `arrangeFunc`
 - reload the subject from the dependency when persistence is part of the contract
 - construct the reconciler or service with common configuration
@@ -93,5 +92,3 @@ Create helpers only for repeated mechanical work. Helpers should expose the arra
 objects := newObjectsForStatefulSet(cluster, statefulSet, sizes)
 createObjects(t, client, objects...)
 ```
-
-over a helper that silently creates the scheme, client, all resources, and scenario-specific overrides before returning only the client.

--- a/.github/skills/table-driven-aaa-tests/SKILL.md
+++ b/.github/skills/table-driven-aaa-tests/SKILL.md
@@ -1,12 +1,20 @@
 ---
 name: table-driven-aaa-tests
-description: 'Refactor or implement Go table-driven tests using case-specific Arrange and Assert functions with one shared Act. Use when consolidating duplicated tests, fake-client fixtures, setup helpers, resource builders, expected-state checks, or subtests while preserving behavior and coverage.'
+description: 'Refactor or implement Go standard-library TestXxx table-driven tests when Arrange or Assert varies by case, using case-specific functions and one shared Act. Use for duplicated tests, fake-client fixtures, setup helpers, resource builders, or expected-state checks. Do not use for Ginkgo specs or tables with common Arrange and Assert logic.'
 argument-hint: 'Describe the Go test file or test cases to refactor'
 ---
 
 # Table-Driven Arrange/Act/Assert Tests
 
-Use this workflow to structure Go tests so each table entry owns its initial state and expected outcome while the test loop owns one common operation under test.
+Use this workflow only for Go standard-library tests declared as `func TestXxx(t *testing.T)`. It does not apply to Ginkgo specs.
+
+## Choose the Test Shape
+
+- Use case-specific `arrangeFunc` and `assertFunc` when Arrange or Assert behavior varies between test cases. Once this pattern is selected, define both functions for every case.
+- Keep setup and assertions that every case needs directly in the `t.Run` body. Do not repeat common work in case functions.
+- When Arrange and Assert are both common, write a conventional table-driven test. Put inputs, options, and expected values in fields such as `input`, `want`, or `wantErr`, and keep the shared Arrange and Assert logic in the test loop.
+
+Different parameter or expected values alone do not justify `arrangeFunc` or `assertFunc`. Use them when the cases need different setup or assertion behavior.
 
 ## Target Shape
 
@@ -30,6 +38,7 @@ testCases := []struct {
 for _, tt := range testCases {
     t.Run(tt.name, func(t *testing.T) {
         dependency := newDependency(t)
+        // common setup for every case...
         tt.arrangeFunc(t, dependency)
 
         subject := loadSubject(t, dependency)
@@ -37,12 +46,11 @@ for _, tt := range testCases {
             t.Fatalf("act failed: %v", err)
         }
 
+        // common assertions for every case...
         tt.assertFunc(t, dependency)
     })
 }
 ```
-
-Adapt the fields for per-case identifiers, expected errors, metrics, events, or configuration. Keep the operation being tested in the common loop.
 
 ## Recommended
 
@@ -61,10 +69,9 @@ struct {
 }
 ```
 
-- `arrangeFunc` creates all case-specific resources and initial values.
-- `assertFunc` reloads results and performs case-specific checks.
-- Expected errors or optional side effects remain fields when their checking logic is common.
-- Do not keep parallel `wantX` fields if only one case-specific assertion closure consumes them more clearly.
+- `arrangeFunc` arranges case-specific resources and initial values.
+- `assertFunc` performs case-specific checks.
+- Keep expected errors or optional side effects as fields when their checking logic is common.
 
 ### Build Fresh Common Infrastructure
 
@@ -76,19 +83,11 @@ Inside each `t.Run`:
 - reload the subject from the dependency when persistence is part of the contract
 - construct the reconciler or service with common configuration
 
-Fresh dependencies prevent state and metrics from leaking between subtests. Move genuinely invariant setup into the common loop; leave resources whose values define a scenario in its Arrange closure.
+Fresh dependencies prevent state and metrics from leaking between subtests. Keep invariant setup in the common loop and scenario-specific state in `arrangeFunc`.
 
 ### Extract Narrow Helpers
 
-Create helpers only for repeated mechanical work, such as:
-
-- building resource objects
-- deriving child objects from templates
-- creating a list of objects in a fake client
-- loading and comparing one resource
-- returning a fresh expected label or annotation map
-
-Helpers should expose the arranged state instead of hiding an entire scenario. Prefer:
+Create helpers only for repeated mechanical work. Helpers should expose the arranged state instead of hiding an entire scenario. Prefer:
 
 ```go
 objects := newObjectsForStatefulSet(cluster, statefulSet, sizes)

--- a/controllers/pvc.go
+++ b/controllers/pvc.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -15,12 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
-)
-
-var (
-	ErrReduceVolumeSize = errors.New("cannot reduce volume size")
 )
 
 // reconcilePVC syncs the PVC and volumeClaimTemplate labels and annotations and resizes the PVC as needed.
@@ -37,8 +33,6 @@ var (
 // The deletion and recreation of the StatefulSet are managed by reconcileV1StatefulSet().
 // Therefore, this function should be called before reconcileV1StatefulSet().
 func (r *MySQLClusterReconciler) reconcilePVC(ctx context.Context, cluster *mocov1beta2.MySQLCluster) error {
-	log := crlog.FromContext(ctx)
-
 	var sts appsv1.StatefulSet
 	err := r.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.PrefixedName()}, &sts)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -55,14 +49,7 @@ func (r *MySQLClusterReconciler) reconcilePVC(ctx context.Context, cluster *moco
 		return nil
 	}
 
-	resizeTarget, ok := r.needResizePVC(cluster, &sts)
-	if !ok {
-		return nil
-	}
-
-	log.Info("Starting PVC resize")
-
-	resized, err := r.resizePVCs(ctx, cluster, &sts, resizeTarget)
+	resized, err := r.resizePVCs(ctx, cluster, &sts)
 	if err != nil {
 		metrics.VolumeResizedErrorTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
 		return err
@@ -77,7 +64,7 @@ func (r *MySQLClusterReconciler) reconcilePVC(ctx context.Context, cluster *moco
 	return nil
 }
 
-func (r *MySQLClusterReconciler) resizePVCs(ctx context.Context, cluster *mocov1beta2.MySQLCluster, sts *appsv1.StatefulSet, resizeTarget map[string]corev1.PersistentVolumeClaim) (map[string]corev1.PersistentVolumeClaim, error) {
+func (r *MySQLClusterReconciler) resizePVCs(ctx context.Context, cluster *mocov1beta2.MySQLCluster, sts *appsv1.StatefulSet) (map[string]corev1.PersistentVolumeClaim, error) {
 	log := crlog.FromContext(ctx)
 
 	newSizes := make(map[string]*resource.Quantity)
@@ -89,18 +76,13 @@ func (r *MySQLClusterReconciler) resizePVCs(ctx context.Context, cluster *mocov1
 		newSizes[pvc.Name] = newSize
 	}
 
-	var replicas int32
-	if sts.Spec.Replicas == nil {
-		replicas = 1
-	} else {
-		replicas = *sts.Spec.Replicas
-	}
-	pvcsToKeep := make(map[string]*resource.Quantity, replicas*int32(len(resizeTarget)))
-	for _, pvc := range resizeTarget {
-		for i := int32(0); i < replicas; i++ {
-			name := fmt.Sprintf("%s-%s-%d", pvc.Name, sts.Name, i)
-			newSize := newSizes[pvc.Name]
-			pvcsToKeep[name] = newSize
+	replicas := ptr.Deref(sts.Spec.Replicas, 1)
+
+	pvcSizes := make(map[string]*resource.Quantity)
+	for templateName, size := range newSizes {
+		for ordinal := int32(0); ordinal < replicas; ordinal++ {
+			name := fmt.Sprintf("%s-%s-%d", templateName, sts.Name, ordinal)
+			pvcSizes[name] = size
 		}
 	}
 
@@ -121,8 +103,15 @@ func (r *MySQLClusterReconciler) resizePVCs(ctx context.Context, cluster *mocov1
 	resizedPVC := make(map[string]corev1.PersistentVolumeClaim)
 
 	for _, pvc := range pvcs.Items {
-		newSize, ok := pvcsToKeep[pvc.Name]
+		newSize, ok := pvcSizes[pvc.Name]
 		if !ok {
+			continue
+		}
+
+		currentSize := pvc.Spec.Resources.Requests.Storage()
+		// If the current size is greater than or equal to the new size, skip resizing.
+		// If the current size is nil, it means that the PVC has no size set and needs to be resized.
+		if currentSize != nil && currentSize.Cmp(*newSize) >= 0 {
 			continue
 		}
 
@@ -131,77 +120,28 @@ func (r *MySQLClusterReconciler) resizePVCs(ctx context.Context, cluster *mocov1
 			return resizedPVC, fmt.Errorf("failed to check if volume expansion is supported: %w", err)
 		}
 		if !supported {
-			log.Info("StorageClass used by PVC does not support volume expansion, skipped", "storageClassName", *pvc.Spec.StorageClassName, "pvcName", pvc.Name)
+			storageClassName := ptr.Deref(pvc.Spec.StorageClassName, "")
+			log.Info("StorageClass used by PVC does not support volume expansion, skipped", "storageClassName", storageClassName, "pvcName", pvc.Name)
 			continue
 		}
 
-		switch i := pvc.Spec.Resources.Requests.Storage().Cmp(*newSize); i {
-		case 0: // volume size is equal
-			continue
-		case 1: // current volume size is greater than new size
-			// The size of the Persistent Volume Claims (PVC) cannot be reduced.
-			// Although MOCO permits the reduction of PVC, an automatic resize is not performed.
-			// An error arises if a PVC involving reduction is passed, as it's unexpected.
-			return resizedPVC, fmt.Errorf("failed to resize pvc %q, want size: %s, deployed size: %s: %w", pvc.Name, newSize.String(), pvc.Spec.Resources.Requests.Storage().String(), ErrReduceVolumeSize)
-		case -1: // current volume size is smaller than new size
-			pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *newSize
+		log.Info("Starting PVC resize", "pvcName", pvc.Name, "currentSize", currentSize.String(), "newSize", newSize.String())
 
-			if err := r.Update(ctx, &pvc); err != nil {
-				return resizedPVC, fmt.Errorf("failed to update PVC: %w", err)
-			}
-
-			log.Info("PVC resized", "pvcName", pvc.Name)
-
-			resizedPVC[pvc.Name] = pvc
+		if pvc.Spec.Resources.Requests == nil {
+			pvc.Spec.Resources.Requests = corev1.ResourceList{}
 		}
+		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *newSize
+
+		if err := r.Update(ctx, &pvc); err != nil {
+			return resizedPVC, fmt.Errorf("failed to update PVC: %w", err)
+		}
+
+		log.Info("PVC resized", "pvcName", pvc.Name)
+
+		resizedPVC[pvc.Name] = pvc
 	}
 
 	return resizedPVC, nil
-}
-
-func (*MySQLClusterReconciler) needResizePVC(cluster *mocov1beta2.MySQLCluster, sts *appsv1.StatefulSet) (map[string]corev1.PersistentVolumeClaim, bool) {
-	if len(sts.Spec.VolumeClaimTemplates) == 0 {
-		return nil, false
-	}
-
-	pvcSet := make(map[string]corev1.PersistentVolumeClaim, len(sts.Spec.VolumeClaimTemplates))
-	for _, pvc := range sts.Spec.VolumeClaimTemplates {
-		pvcSet[pvc.Name] = pvc
-	}
-
-	resizeTarget := make(map[string]corev1.PersistentVolumeClaim)
-
-	for _, pvc := range cluster.Spec.VolumeClaimTemplates {
-		if _, ok := pvcSet[pvc.Name]; !ok {
-			continue
-		}
-
-		current := pvcSet[pvc.Name]
-
-		deployedSize := current.Spec.Resources.Requests.Storage()
-		wantSize := pvc.Spec.Resources.Requests.Storage()
-
-		switch i := deployedSize.Cmp(wantSize.DeepCopy()); i {
-		case 0: // volume size is equal
-			continue
-		case 1: // volume size is greater
-			// Due to the lack of support for volume size reduction, resizing will not be executed if it implies a smaller size.
-			// It's important to highlight that this does not induce an error.
-			// Instead, the recreation of the StatefulSet will be managed in the reconcileV1StatefulSet() operation, which follows this one.
-			// Hence, the execution flow remains uninterrupted.
-			// ref: docs/designdoc/support_reduce_volume_size.md
-			continue
-		case -1: // volume size is smaller
-			resizeTarget[pvc.Name] = pvcSet[pvc.Name]
-			continue
-		}
-	}
-
-	if len(resizeTarget) == 0 {
-		return nil, false
-	}
-
-	return resizeTarget, true
 }
 
 func (r *MySQLClusterReconciler) isVolumeExpansionSupported(ctx context.Context, pvc *corev1.PersistentVolumeClaim) (bool, error) {

--- a/controllers/pvc.go
+++ b/controllers/pvc.go
@@ -69,6 +69,9 @@ func (r *MySQLClusterReconciler) resizePVCs(ctx context.Context, cluster *mocov1
 
 	newSizes := make(map[string]*resource.Quantity)
 	for _, pvc := range cluster.Spec.VolumeClaimTemplates {
+		if pvc.Spec.Resources == nil || pvc.Spec.Resources.Requests == nil {
+			continue
+		}
 		newSize := pvc.Spec.Resources.Requests.Storage()
 		if newSize == nil {
 			continue

--- a/controllers/pvc.go
+++ b/controllers/pvc.go
@@ -80,7 +80,7 @@ func (r *MySQLClusterReconciler) resizePVCs(ctx context.Context, cluster *mocov1
 
 	pvcSizes := make(map[string]*resource.Quantity)
 	for templateName, size := range newSizes {
-		for ordinal := int32(0); ordinal < replicas; ordinal++ {
+		for ordinal := range replicas {
 			name := fmt.Sprintf("%s-%s-%d", templateName, sts.Name, ordinal)
 			pvcSizes[name] = size
 		}

--- a/controllers/pvc_test.go
+++ b/controllers/pvc_test.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"context"
 	"fmt"
 	"maps"
 	"strings"
@@ -21,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -29,27 +29,24 @@ import (
 
 func TestReconcilePVC(t *testing.T) {
 	tests := []struct {
-		name            string
-		cluster         *mocov1beta2.MySQLCluster
-		setupClient     func(*testing.T) client.Client
-		wantSize        resource.Quantity
-		wantLabels      map[string]string
-		wantAnnotations map[string]string
-		wantMetrics     string
+		name        string
+		clusterName string
+		arrangeFunc func(*testing.T, client.Client)
+		assertFunc  func(*testing.T, client.Client)
+		wantMetrics string
 	}{
 		{
-			name:    "resize succeeded",
-			cluster: newMySQLClusterWithVolumeSize(resource.MustParse("2Gi")),
-			setupClient: func(t *testing.T) client.Client {
+			name:        "resize succeeded",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
 				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
 				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
-				return setupMockClient(t, cluster, sts)
+				pvcs := newPVCsForStatefulSet(sts, nil)
+				objects := append([]client.Object{cluster, sts}, pvcs...)
+				createObjects(t, c, objects...)
 			},
-			wantSize: resource.MustParse("2Gi"),
-			wantLabels: map[string]string{
-				"app.kubernetes.io/created-by": "moco",
-				"app.kubernetes.io/instance":   "mysql-cluster",
-				"app.kubernetes.io/name":       "mysql",
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("2Gi"), mysqlPVCLabels(), nil)
 			},
 			wantMetrics: `# HELP moco_cluster_volume_resized_total The number of successful volume resizes
 # TYPE moco_cluster_volume_resized_total counter
@@ -57,107 +54,141 @@ moco_cluster_volume_resized_total{name="mysql-cluster",namespace="default"} 1
 `,
 		},
 		{
-			name: "label synced",
-			cluster: func() *mocov1beta2.MySQLCluster {
+			name:        "PVC without storage request",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
+				pvcs := newPVCsForStatefulSet(sts, nil)
+				pvcs[0].(*corev1.PersistentVolumeClaim).Spec.Resources.Requests = make(corev1.ResourceList)
+				objects := append([]client.Object{cluster, sts}, pvcs...)
+				createObjects(t, c, objects...)
+			},
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("2Gi"), mysqlPVCLabels(), nil)
+			},
+			wantMetrics: `# HELP moco_cluster_volume_resized_total The number of successful volume resizes
+# TYPE moco_cluster_volume_resized_total counter
+moco_cluster_volume_resized_total{name="mysql-cluster",namespace="default"} 1
+`,
+		},
+		{
+			name:        "non-expandable StorageClass",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
+				sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = new("non-expandable")
+				pvcs := newPVCsForStatefulSet(sts, nil)
+				objects := append([]client.Object{cluster, sts, newNonExpandableStorageClass()}, pvcs...)
+				createObjects(t, c, objects...)
+			},
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("1Gi"), mysqlPVCLabels(), nil)
+			},
+		},
+		{
+			name:        "actual PVC is larger than requested size",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("300Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("200Gi"))
+				pvcs := newPVCsForStatefulSet(sts, map[string]resource.Quantity{
+					"mysql-data-moco-mysql-cluster-0": resource.MustParse("500Gi"),
+				})
+				objects := append([]client.Object{cluster, sts}, pvcs...)
+				createObjects(t, c, objects...)
+			},
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("500Gi"), mysqlPVCLabels(), nil)
+			},
+		},
+		{
+			name:        "label synced",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
 				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
 				cluster.Spec.VolumeClaimTemplates[0].Labels = map[string]string{
 					"need-update": "updated",
 					"foo":         "updated",
-				}
-				return cluster
-			}(),
-			setupClient: func(t *testing.T) client.Client {
-				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
-				cluster.Spec.VolumeClaimTemplates[0].Labels = map[string]string{
-					"need-update": "not-updated",
-					"foo":         "not-updated",
 				}
 				sts := newStatefulSetWithVolumeSize(resource.MustParse("2Gi"))
 				sts.Spec.VolumeClaimTemplates[0].Labels = map[string]string{
 					"need-update": "not-updated",
 					"foo":         "not-updated",
 				}
-				return setupMockClient(t, cluster, sts)
+				pvcs := newPVCsForStatefulSet(sts, nil)
+				objects := append([]client.Object{cluster, sts}, pvcs...)
+				createObjects(t, c, objects...)
 			},
-			wantSize: resource.MustParse("2Gi"),
-			wantLabels: map[string]string{
-				"app.kubernetes.io/created-by": "moco",
-				"app.kubernetes.io/instance":   "mysql-cluster",
-				"app.kubernetes.io/name":       "mysql",
-				"need-update":                  "updated",
-				"foo":                          "not-updated",
+			assertFunc: func(t *testing.T, c client.Client) {
+				wantLabels := mysqlPVCLabels()
+				wantLabels["need-update"] = "updated"
+				wantLabels["foo"] = "not-updated"
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("2Gi"), wantLabels, nil)
 			},
 		},
 		{
-			name: "annotation synced",
-			cluster: func() *mocov1beta2.MySQLCluster {
+			name:        "annotation synced",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
 				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
 				cluster.Spec.VolumeClaimTemplates[0].Annotations = map[string]string{
 					"need-update": "updated",
 					"foo":         "updated",
-				}
-				return cluster
-			}(),
-			setupClient: func(t *testing.T) client.Client {
-				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
-				cluster.Spec.VolumeClaimTemplates[0].Annotations = map[string]string{
-					"need-update": "not-updated",
-					"foo":         "not-updated",
 				}
 				sts := newStatefulSetWithVolumeSize(resource.MustParse("2Gi"))
 				sts.Spec.VolumeClaimTemplates[0].Annotations = map[string]string{
 					"need-update": "not-updated",
 					"foo":         "not-updated",
 				}
-				return setupMockClient(t, cluster, sts)
+				pvcs := newPVCsForStatefulSet(sts, nil)
+				objects := append([]client.Object{cluster, sts}, pvcs...)
+				createObjects(t, c, objects...)
 			},
-			wantSize: resource.MustParse("2Gi"),
-			wantLabels: map[string]string{
-				"app.kubernetes.io/created-by": "moco",
-				"app.kubernetes.io/instance":   "mysql-cluster",
-				"app.kubernetes.io/name":       "mysql",
-			},
-			wantAnnotations: map[string]string{
-				"need-update": "updated",
-				"foo":         "not-updated",
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("2Gi"), mysqlPVCLabels(), map[string]string{
+					"need-update": "updated",
+					"foo":         "not-updated",
+				})
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			scheme := runtime.NewScheme()
+			if err := clientgoscheme.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to add scheme: %v", err)
+			}
+			if err := mocov1beta2.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to add scheme: %v", err)
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			createObjects(t, c, newExpandableStorageClass())
+			tt.arrangeFunc(t, c)
+
+			var cluster mocov1beta2.MySQLCluster
+			if err := c.Get(t.Context(), types.NamespacedName{Name: tt.clusterName, Namespace: "default"}, &cluster); err != nil {
+				t.Fatalf("failed to get MySQLCluster: %v", err)
+			}
+
 			registry := prometheus.NewRegistry()
+			metrics.Register(registry)
+
 			r := &MySQLClusterReconciler{
-				Client:                tt.setupClient(t),
+				Client:                c,
 				PVCSyncAnnotationKeys: []string{"need-update"},
 				PVCSyncLabelKeys:      []string{"need-update"},
 			}
 
-			metrics.Register(registry)
-
-			err := r.reconcilePVC(ctx, tt.cluster)
-			if err != nil {
+			if err := r.reconcilePVC(t.Context(), &cluster); err != nil {
 				t.Fatalf("reconcilePVC() error = %v", err)
 			}
 
-			var pvc corev1.PersistentVolumeClaim
-			if err := r.Get(ctx, types.NamespacedName{Name: "mysql-data-moco-mysql-cluster-0", Namespace: tt.cluster.Namespace}, &pvc); err != nil {
-				t.Fatalf("failed to get PVC: %v", err)
-			}
-			if !pvc.Spec.Resources.Requests.Storage().Equal(tt.wantSize) {
-				t.Errorf("unexpected PVC size: got: %s, want: %s", pvc.Spec.Resources.Requests.Storage().String(), tt.wantSize.String())
-			}
-			if diff := cmp.Diff(tt.wantLabels, pvc.Labels); len(diff) != 0 {
-				t.Errorf("unexpected PVC labels: %s", diff)
-			}
-			if diff := cmp.Diff(tt.wantAnnotations, pvc.Annotations); len(diff) != 0 {
-				t.Errorf("unexpected PVC annotations: %s", diff)
-			}
+			tt.assertFunc(t, c)
 
-			if len(tt.wantMetrics) == 0 {
-				return
-			}
 			if err := testutil.GatherAndCompare(registry, strings.NewReader(tt.wantMetrics), "moco_cluster_volume_resized_total"); err != nil {
 				t.Errorf("metrics comparison failed: %v", err)
 			}
@@ -165,186 +196,88 @@ moco_cluster_volume_resized_total{name="mysql-cluster",namespace="default"} 1
 	}
 }
 
-func setupMockClient(t *testing.T, cluster *mocov1beta2.MySQLCluster, sts *appsv1.StatefulSet) client.Client {
-	t.Helper()
-
-	scheme := runtime.NewScheme()
-	if err := clientgoscheme.AddToScheme(scheme); err != nil {
-		t.Fatalf("failed to add scheme: %v", err)
-	}
-	if err := mocov1beta2.AddToScheme(scheme); err != nil {
-		t.Fatalf("failed to add scheme: %v", err)
-	}
-
+func newPVCsForStatefulSet(sts *appsv1.StatefulSet, pvcSizes map[string]resource.Quantity) []client.Object {
 	var pvcs []client.Object
 
-	for _, pvc := range sts.Spec.VolumeClaimTemplates {
-		for i := int32(0); i < *sts.Spec.Replicas; i++ {
-			pvc.Name = fmt.Sprintf("%s-%s-%d", pvc.Name, cluster.PrefixedName(), i)
-			pvc.Namespace = cluster.Namespace
+	replicas := ptr.Deref(sts.Spec.Replicas, 1)
+
+	for _, template := range sts.Spec.VolumeClaimTemplates {
+		for i := int32(0); i < replicas; i++ {
+			pvc := template.DeepCopy()
+			pvc.Name = fmt.Sprintf("%s-%s-%d", template.Name, sts.Name, i)
+			pvc.Namespace = "default"
 
 			labels := make(map[string]string)
 			maps.Copy(labels, pvc.Labels)
 			maps.Copy(labels, sts.Spec.Selector.MatchLabels)
 			pvc.Labels = labels
 
-			pvc.Spec.StorageClassName = new("default")
-			pvcs = append(pvcs, &pvc)
+			if size, ok := pvcSizes[pvc.Name]; ok {
+				if pvc.Spec.Resources.Requests == nil {
+					pvc.Spec.Resources.Requests = corev1.ResourceList{}
+				}
+				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = size
+			}
+			pvcs = append(pvcs, pvc)
 		}
 	}
 
-	storageClass := &storagev1.StorageClass{
+	return pvcs
+}
+
+func newExpandableStorageClass() *storagev1.StorageClass {
+	return &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
 		},
 		Provisioner:          "kubernetes.io/no-provisioner",
 		AllowVolumeExpansion: new(true),
 	}
-
-	client := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(cluster, sts, storageClass).
-		WithObjects(pvcs...).
-		Build()
-
-	return client
 }
 
-func TestNeedResizePVC(t *testing.T) {
-	tests := []struct {
-		name             string
-		cluster          *mocov1beta2.MySQLCluster
-		sts              *appsv1.StatefulSet
-		wantResizeTarget map[string]corev1.PersistentVolumeClaim
-		wantResize       bool
-		wantError        error
-	}{
-		{
-			name:       "no resizing",
-			cluster:    newMySQLClusterWithVolumeSize(resource.MustParse("1Gi")),
-			sts:        newStatefulSetWithVolumeSize(resource.MustParse("1Gi")),
-			wantResize: false,
+func newNonExpandableStorageClass() *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "non-expandable",
 		},
-		{
-			name:    "need resizing",
-			cluster: newMySQLClusterWithVolumeSize(resource.MustParse("2Gi")),
-			sts:     newStatefulSetWithVolumeSize(resource.MustParse("1Gi")),
-			wantResizeTarget: func() map[string]corev1.PersistentVolumeClaim {
-				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
-				pvc := sts.Spec.VolumeClaimTemplates[0]
-				m := make(map[string]corev1.PersistentVolumeClaim)
-				m[pvc.Name] = pvc
-				return m
-			}(),
-			wantResize: true,
-		},
-		{
-			name:       "reduce volume size error",
-			cluster:    newMySQLClusterWithVolumeSize(resource.MustParse("1Gi")),
-			sts:        newStatefulSetWithVolumeSize(resource.MustParse("2Gi")),
-			wantResize: false,
-		},
-		{
-			name:    "StatefulSet has more PVCs",
-			cluster: newMySQLClusterWithVolumeSize(resource.MustParse("1Gi")),
-			sts: func() *appsv1.StatefulSet {
-				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
-				pvc := corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "new-data",
-					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: new("default"),
-						Resources: corev1.VolumeResourceRequirements{
-							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
-						},
-					},
-				}
-
-				sts.Spec.VolumeClaimTemplates = append(sts.Spec.VolumeClaimTemplates, pvc)
-
-				return sts
-			}(),
-			wantResize: false,
-		},
-		{
-			name: "MySQLCluster has more PVCs",
-			cluster: func() *mocov1beta2.MySQLCluster {
-				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("1Gi"))
-				pvc := mocov1beta2.PersistentVolumeClaim{
-					ObjectMeta: mocov1beta2.ObjectMeta{Name: "new-data"},
-					Spec: mocov1beta2.PersistentVolumeClaimSpecApplyConfiguration(*corev1ac.PersistentVolumeClaimSpec().
-						WithStorageClassName("default").WithResources(corev1ac.VolumeResourceRequirements().
-						WithRequests(corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}),
-					)),
-				}
-				cluster.Spec.VolumeClaimTemplates = append(cluster.Spec.VolumeClaimTemplates, pvc)
-				return cluster
-			}(),
-			sts:        newStatefulSetWithVolumeSize(resource.MustParse("1Gi")),
-			wantResize: false,
-		},
-		{
-			name: "Mix expansion and reduction",
-			cluster: func() *mocov1beta2.MySQLCluster {
-				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
-				pvc := mocov1beta2.PersistentVolumeClaim{
-					ObjectMeta: mocov1beta2.ObjectMeta{Name: "new-data"},
-					Spec: mocov1beta2.PersistentVolumeClaimSpecApplyConfiguration(*corev1ac.PersistentVolumeClaimSpec().
-						WithStorageClassName("default").WithResources(corev1ac.VolumeResourceRequirements().
-						WithRequests(corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}),
-					)),
-				}
-				cluster.Spec.VolumeClaimTemplates = append(cluster.Spec.VolumeClaimTemplates, pvc)
-				return cluster
-			}(),
-			sts: func() *appsv1.StatefulSet {
-				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
-				pvc := corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "new-data",
-					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: new("default"),
-						Resources: corev1.VolumeResourceRequirements{
-							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")},
-						},
-					},
-				}
-
-				sts.Spec.VolumeClaimTemplates = append(sts.Spec.VolumeClaimTemplates, pvc)
-
-				return sts
-			}(),
-			wantResizeTarget: func() map[string]corev1.PersistentVolumeClaim {
-				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
-				pvc := sts.Spec.VolumeClaimTemplates[0]
-				m := make(map[string]corev1.PersistentVolumeClaim)
-				m[pvc.Name] = pvc
-				return m
-			}(),
-			wantResize: true,
-		},
+		Provisioner:          "kubernetes.io/no-provisioner",
+		AllowVolumeExpansion: new(false),
 	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := &MySQLClusterReconciler{}
-			resizeTarget, resize := r.needResizePVC(tt.cluster, tt.sts)
-			if tt.wantResize != resize {
-				t.Fatalf("want resize %v, got %v", tt.wantResize, resize)
-			}
+func createObjects(t *testing.T, c client.Client, objects ...client.Object) {
+	t.Helper()
 
-			if len(tt.wantResizeTarget) != len(resizeTarget) {
-				t.Fatalf("want resize target length %v, got %v", len(tt.wantResizeTarget), len(resizeTarget))
-			}
+	for _, object := range objects {
+		if err := c.Create(t.Context(), object); err != nil {
+			t.Fatalf("failed to create %T %s: %v", object, client.ObjectKeyFromObject(object), err)
+		}
+	}
+}
 
-			for key, value := range tt.wantResizeTarget {
-				if diff := cmp.Diff(value, resizeTarget[key]); len(diff) != 0 {
-					t.Fatalf("unexpected resize target: %s", diff)
-				}
-			}
-		})
+func assertPVC(t *testing.T, c client.Client, name string, wantSize resource.Quantity, wantLabels, wantAnnotations map[string]string) {
+	t.Helper()
+
+	var pvc corev1.PersistentVolumeClaim
+	if err := c.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "default"}, &pvc); err != nil {
+		t.Fatalf("failed to get PVC %q: %v", name, err)
+	}
+	if got := pvc.Spec.Resources.Requests.Storage(); !got.Equal(wantSize) {
+		t.Errorf("unexpected PVC %q size: got: %s, want: %s", name, got.String(), wantSize.String())
+	}
+	if diff := cmp.Diff(wantLabels, pvc.Labels); len(diff) != 0 {
+		t.Errorf("unexpected PVC %q labels: %s", name, diff)
+	}
+	if diff := cmp.Diff(wantAnnotations, pvc.Annotations); len(diff) != 0 {
+		t.Errorf("unexpected PVC %q annotations: %s", name, diff)
+	}
+}
+
+func mysqlPVCLabels() map[string]string {
+	return map[string]string{
+		constants.LabelAppName:      constants.AppNameMySQL,
+		constants.LabelAppCreatedBy: constants.AppCreator,
+		constants.LabelAppInstance:  "mysql-cluster",
 	}
 }
 

--- a/controllers/pvc_test.go
+++ b/controllers/pvc_test.go
@@ -202,7 +202,7 @@ func newPVCsForStatefulSet(sts *appsv1.StatefulSet, pvcSizes map[string]resource
 	replicas := ptr.Deref(sts.Spec.Replicas, 1)
 
 	for _, template := range sts.Spec.VolumeClaimTemplates {
-		for i := int32(0); i < replicas; i++ {
+		for i := range replicas {
 			pvc := template.DeepCopy()
 			pvc.Name = fmt.Sprintf("%s-%s-%d", template.Name, sts.Name, i)
 			pvc.Namespace = "default"

--- a/controllers/pvc_test.go
+++ b/controllers/pvc_test.go
@@ -36,17 +36,19 @@ func TestReconcilePVC(t *testing.T) {
 		wantMetrics string
 	}{
 		{
-			name:        "resize succeeded",
+			name:        "actual PVC is smaller than requested size",
 			clusterName: "mysql-cluster",
 			arrangeFunc: func(t *testing.T, c client.Client) {
-				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
-				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
-				pvcs := newPVCsForStatefulSet(sts, nil)
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("300Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("200Gi"))
+				pvcs := newPVCsForStatefulSet(sts, map[string]resource.Quantity{
+					"mysql-data-moco-mysql-cluster-0": resource.MustParse("250Gi"),
+				})
 				objects := append([]client.Object{cluster, sts}, pvcs...)
 				createObjects(t, c, objects...)
 			},
 			assertFunc: func(t *testing.T, c client.Client) {
-				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("2Gi"), mysqlPVCLabels(), nil)
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("300Gi"), mysqlPVCLabels(), nil)
 			},
 			wantMetrics: `# HELP moco_cluster_volume_resized_total The number of successful volume resizes
 # TYPE moco_cluster_volume_resized_total counter
@@ -54,37 +56,19 @@ moco_cluster_volume_resized_total{name="mysql-cluster",namespace="default"} 1
 `,
 		},
 		{
-			name:        "PVC without storage request",
+			name:        "actual PVC is equal to requested size",
 			clusterName: "mysql-cluster",
 			arrangeFunc: func(t *testing.T, c client.Client) {
-				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
-				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
-				pvcs := newPVCsForStatefulSet(sts, nil)
-				pvcs[0].(*corev1.PersistentVolumeClaim).Spec.Resources.Requests = make(corev1.ResourceList)
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("300Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("200Gi"))
+				pvcs := newPVCsForStatefulSet(sts, map[string]resource.Quantity{
+					"mysql-data-moco-mysql-cluster-0": resource.MustParse("300Gi"),
+				})
 				objects := append([]client.Object{cluster, sts}, pvcs...)
 				createObjects(t, c, objects...)
 			},
 			assertFunc: func(t *testing.T, c client.Client) {
-				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("2Gi"), mysqlPVCLabels(), nil)
-			},
-			wantMetrics: `# HELP moco_cluster_volume_resized_total The number of successful volume resizes
-# TYPE moco_cluster_volume_resized_total counter
-moco_cluster_volume_resized_total{name="mysql-cluster",namespace="default"} 1
-`,
-		},
-		{
-			name:        "non-expandable StorageClass",
-			clusterName: "mysql-cluster",
-			arrangeFunc: func(t *testing.T, c client.Client) {
-				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
-				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
-				sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = new("non-expandable")
-				pvcs := newPVCsForStatefulSet(sts, nil)
-				objects := append([]client.Object{cluster, sts, newNonExpandableStorageClass()}, pvcs...)
-				createObjects(t, c, objects...)
-			},
-			assertFunc: func(t *testing.T, c client.Client) {
-				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("1Gi"), mysqlPVCLabels(), nil)
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("300Gi"), mysqlPVCLabels(), nil)
 			},
 		},
 		{
@@ -102,6 +86,129 @@ moco_cluster_volume_resized_total{name="mysql-cluster",namespace="default"} 1
 			assertFunc: func(t *testing.T, c client.Client) {
 				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("500Gi"), mysqlPVCLabels(), nil)
 			},
+		},
+		{
+			name:        "PVC without storage request",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("300Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("200Gi"))
+				pvcs := newPVCsForStatefulSet(sts, nil)
+				pvcs[0].(*corev1.PersistentVolumeClaim).Spec.Resources.Requests = make(corev1.ResourceList)
+				objects := append([]client.Object{cluster, sts}, pvcs...)
+				createObjects(t, c, objects...)
+			},
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("300Gi"), mysqlPVCLabels(), nil)
+			},
+			wantMetrics: `# HELP moco_cluster_volume_resized_total The number of successful volume resizes
+# TYPE moco_cluster_volume_resized_total counter
+moco_cluster_volume_resized_total{name="mysql-cluster",namespace="default"} 1
+`,
+		},
+		{
+			name:        "MySQLCluster without storage request",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("300Gi"))
+				cluster.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests = nil
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("200Gi"))
+				pvcs := newPVCsForStatefulSet(sts, map[string]resource.Quantity{
+					"mysql-data-moco-mysql-cluster-0": resource.MustParse("200Gi"),
+				})
+				objects := append([]client.Object{cluster, sts}, pvcs...)
+				createObjects(t, c, objects...)
+			},
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("200Gi"), mysqlPVCLabels(), nil)
+			},
+		},
+		{
+			name:        "non-expandable StorageClass",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("2Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("1Gi"))
+				sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = new("non-expandable")
+				pvcs := newPVCsForStatefulSet(sts, nil)
+				objects := append([]client.Object{cluster, sts, newNonExpandableStorageClass()}, pvcs...)
+				createObjects(t, c, objects...)
+			},
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("1Gi"), mysqlPVCLabels(), nil)
+			},
+		},
+		{
+			name:        "StatefulSet is updating",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("300Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("200Gi"))
+				sts.Generation = 2
+				pvcs := newPVCsForStatefulSet(sts, map[string]resource.Quantity{
+					"mysql-data-moco-mysql-cluster-0": resource.MustParse("250Gi"),
+				})
+				objects := append([]client.Object{cluster, sts}, pvcs...)
+				createObjects(t, c, objects...)
+			},
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("250Gi"), mysqlPVCLabels(), nil)
+			},
+		},
+		{
+			name:        "PVC with unrelated name is not resized",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("300Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("200Gi"))
+				pvcs := newPVCsForStatefulSet(sts, map[string]resource.Quantity{
+					"mysql-data-moco-mysql-cluster-0": resource.MustParse("200Gi"),
+				})
+				unrelatedPvc := pvcs[0].(*corev1.PersistentVolumeClaim).DeepCopy()
+				unrelatedPvc.Name = "unrelated-moco-mysql-cluster-0"
+				objects := append([]client.Object{cluster, sts, unrelatedPvc}, pvcs...)
+				createObjects(t, c, objects...)
+			},
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("300Gi"), mysqlPVCLabels(), nil)
+				assertPVC(t, c, "unrelated-moco-mysql-cluster-0", resource.MustParse("200Gi"), mysqlPVCLabels(), nil)
+			},
+			wantMetrics: `# HELP moco_cluster_volume_resized_total The number of successful volume resizes
+# TYPE moco_cluster_volume_resized_total counter
+moco_cluster_volume_resized_total{name="mysql-cluster",namespace="default"} 1
+`,
+		},
+		{
+			name:        "StatefulSet does not exist",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				createObjects(t, c, newMySQLClusterWithVolumeSize(resource.MustParse("300Gi")))
+			},
+			assertFunc: func(t *testing.T, c client.Client) {},
+		},
+		{
+			name:        "multiple PVCs with mixed sizes",
+			clusterName: "mysql-cluster",
+			arrangeFunc: func(t *testing.T, c client.Client) {
+				cluster := newMySQLClusterWithVolumeSize(resource.MustParse("300Gi"))
+				sts := newStatefulSetWithVolumeSize(resource.MustParse("200Gi"))
+				sts.Spec.Replicas = new(int32(2))
+				sts.Status.ReadyReplicas = 2
+				pvcs := newPVCsForStatefulSet(sts, map[string]resource.Quantity{
+					"mysql-data-moco-mysql-cluster-0": resource.MustParse("250Gi"),
+					"mysql-data-moco-mysql-cluster-1": resource.MustParse("500Gi"),
+				})
+				objects := append([]client.Object{cluster, sts}, pvcs...)
+				createObjects(t, c, objects...)
+			},
+			assertFunc: func(t *testing.T, c client.Client) {
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-0", resource.MustParse("300Gi"), mysqlPVCLabels(), nil)
+				assertPVC(t, c, "mysql-data-moco-mysql-cluster-1", resource.MustParse("500Gi"), mysqlPVCLabels(), nil)
+			},
+			wantMetrics: `# HELP moco_cluster_volume_resized_total The number of successful volume resizes
+# TYPE moco_cluster_volume_resized_total counter
+moco_cluster_volume_resized_total{name="mysql-cluster",namespace="default"} 1
+`,
 		},
 		{
 			name:        "label synced",


### PR DESCRIPTION
Fix #933