### PR TITLE
Stop dropping log entries and unify the log format

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cybozu-go/moco/pkg/constants"
 	"github.com/cybozu-go/moco/pkg/event"
 	"github.com/go-logr/logr"
-	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,7 +29,7 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type BackupManager struct {
@@ -56,7 +55,7 @@ type BackupManager struct {
 }
 
 func NewBackupManager(cfg *rest.Config, bc bucket.Bucket, dir, ns, name, password string, threads int) (*BackupManager, error) {
-	log := zap.New(zap.WriteTo(os.Stderr), zap.StacktraceLevel(zapcore.DPanicLevel))
+	log := crlog.Log.WithName("backup")
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
 		return nil, err

--- a/backup/restore.go
+++ b/backup/restore.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cybozu-go/moco/pkg/constants"
 	"github.com/cybozu-go/moco/pkg/event"
 	"github.com/go-logr/logr"
-	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,7 +26,7 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type RestoreManager struct {
@@ -49,7 +48,7 @@ type RestoreManager struct {
 var ErrBadConnection = errors.New("the connection hasn't reflected the latest user's privileges")
 
 func NewRestoreManager(cfg *rest.Config, bc bucket.Bucket, dir, srcNS, srcName, ns, name, password string, threads int, restorePoint time.Time, schema, users string) (*RestoreManager, error) {
-	log := zap.New(zap.WriteTo(os.Stderr), zap.StacktraceLevel(zapcore.DPanicLevel))
+	log := crlog.Log.WithName("restore")
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
 		return nil, err

--- a/cmd/moco-backup/cmd/root.go
+++ b/cmd/moco-backup/cmd/root.go
@@ -15,7 +15,10 @@ import (
 	"github.com/cybozu-go/moco"
 	"github.com/cybozu-go/moco/pkg/bucket"
 	"github.com/cybozu-go/moco/pkg/constants"
+	mocolog "github.com/cybozu-go/moco/pkg/log"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var commonArgs struct {
@@ -116,6 +119,8 @@ var rootCmd = &cobra.Command{
 	Long:    "Backup and restore MySQL data.",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
+
+		mocolog.Setup(&zap.Options{StacktraceLevel: zapcore.DPanicLevel})
 
 		if len(mysqlPassword) == 0 {
 			return errors.New("no MYSQL_PASSWORD environment variable")

--- a/cmd/moco-controller/cmd/root.go
+++ b/cmd/moco-controller/cmd/root.go
@@ -121,7 +121,29 @@ func init() {
 
 	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(goflags)
-	config.zapOpts.BindFlags(goflags)
 
+	// The other klog flags configure the output of klog itself, which is unused
+	// because the entries from klog are encoded by zap. See pkg/log.
+	effective := map[string]bool{"v": true, "vmodule": true, "log_backtrace_at": true}
+	var obsolete []string
+	goflags.VisitAll(func(f *flag.Flag) {
+		if !effective[f.Name] {
+			obsolete = append(obsolete, f.Name)
+			return
+		}
+		f.Usage += " (only for klog entries, e.g. from client-go)"
+		if f.Name == "v" {
+			f.Usage += ". --zap-log-level needs to be raised as well to see them"
+		}
+	})
+
+	config.zapOpts.BindFlags(goflags)
 	fs.AddGoFlagSet(goflags)
+
+	for _, name := range obsolete {
+		// MarkDeprecated hides the flag as well.
+		if err := fs.MarkDeprecated(name, "this flag has no effect and may be removed in the future"); err != nil {
+			panic(err)
+		}
+	}
 }

--- a/cmd/moco-controller/cmd/run.go
+++ b/cmd/moco-controller/cmd/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cybozu-go/moco/controllers"
 	"github.com/cybozu-go/moco/pkg/cert"
 	"github.com/cybozu-go/moco/pkg/dbop"
+	mocolog "github.com/cybozu-go/moco/pkg/log"
 	"github.com/cybozu-go/moco/pkg/metrics"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
@@ -19,7 +20,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -56,7 +56,7 @@ func (r resolver) Resolve(ctx context.Context, cluster *mocov1beta2.MySQLCluster
 }
 
 func subMain(ns, addr string, port int) error {
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&config.zapOpts)))
+	mocolog.Setup(&config.zapOpts)
 	setupLog := ctrl.Log.WithName("setup")
 	clusterLog := ctrl.Log.WithName("cluster-manager")
 	clustering.SetDefaultLogger(clusterLog)

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -1763,11 +1763,11 @@ func (r *MySQLClusterReconciler) updateStatus(ctx context.Context, cluster *moco
 	if err != nil && apierrors.IsNotFound(err) {
 		reason = "StatefulSetNotFound"
 		message = "StatefulSet not found"
-		log.Error(err, "StatefulSet not found", "namespace", cluster.Namespace, "name", cluster.PrefixedName())
+		log.Error(err, "StatefulSet not found", "statefulSet", cluster.PrefixedName())
 	} else if err != nil {
 		reason = "FaildToGetStatefulSet"
 		message = "failed to get StatefulSet"
-		log.Error(err, "failed to get StatefulSet", "namespace", cluster.Namespace, "name", cluster.PrefixedName())
+		log.Error(err, "failed to get StatefulSet", "statefulSet", cluster.PrefixedName())
 	} else if sts.Spec.Replicas != nil && sts.Status.AvailableReplicas == *sts.Spec.Replicas && sts.Status.CurrentRevision == sts.Status.UpdateRevision && sts.Generation == sts.Status.ObservedGeneration {
 		stsReady = metav1.ConditionTrue
 		reason = "StatefulSetReady"

--- a/controllers/partition_controller.go
+++ b/controllers/partition_controller.go
@@ -168,7 +168,7 @@ func (r *StatefulSetPartitionReconciler) isRolloutReady(ctx context.Context, clu
 	// Even if the MySQLCluster is not healthy, the rollout continues if the rollout target Pod is not ready.
 	// This is because there is an expectation that restarting the Not Ready Pod might improve its state.
 	if podutils.IsPodReady(&podList.Items[nextRolloutTarget]) && !r.isMySQLClusterHealthy(cluster) {
-		log.Info("MySQLCluster is not healthy", "name", cluster.Name, "namespace", cluster.Namespace)
+		log.Info("MySQLCluster is not healthy", "mysqlCluster", cluster.Name)
 		return false, nil
 	}
 

--- a/controllers/pod_watcher.go
+++ b/controllers/pod_watcher.go
@@ -75,9 +75,9 @@ func (r *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if pod.DeletionTimestamp != nil {
-		log.Info("detected mysql pod deletion", "name", pod.Name)
+		log.Info("detected mysql pod deletion")
 	} else {
-		log.Info("detected demote annotation", "name", pod.Name)
+		log.Info("detected demote annotation")
 	}
 	r.ClusterManager.UpdateNoStart(types.NamespacedName{Namespace: pod.Namespace, Name: ref.Name}, string(controller.ReconcileIDFromContext(ctx)))
 	return ctrl.Result{}, nil

--- a/docs/moco-controller.md
+++ b/docs/moco-controller.md
@@ -12,9 +12,7 @@
 
 ```
 Flags:
-      --add_dir_header                      If true, adds the file directory to the header of the log messages
       --agent-image string                  The image of moco-agent sidecar container (default "ghcr.io/cybozu-go/moco-agent:0.15.0")
-      --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --apiserver-qps-throttle int          The maximum QPS to the API server. (default 20)
       --backup-image string                 The image of moco-backup container (default "ghcr.io/cybozu-go/moco-backup:0.23.2")
       --cert-dir string                     webhook certificate directory
@@ -25,26 +23,18 @@ Flags:
       --health-probe-addr string            Listen address for health probes (default ":8081")
   -h, --help                                help for moco-controller
       --leader-election-id string           ID for leader election by controller-runtime (default "moco")
-      --log_backtrace_at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                     If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint              Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                         log to standard error instead of files (default true)
+      --log_backtrace_at traceLocation      when logging hits line file:N, emit a stack trace (only for klog entries, e.g. from client-go) (default :0)
       --max-concurrent-reconciles int       The maximum number of concurrent reconciles which can be run (default 8)
       --metrics-addr string                 Listen address for metric endpoint (default ":8080")
       --mysql-configmap-history-limit int   The maximum number of MySQLConfigMap's history to be kept (default 10)
       --mysqld-exporter-image string        The image of mysqld_exporter sidecar container (default "ghcr.io/cybozu-go/moco/mysqld_exporter:0.15.1.2")
-      --one_output                          If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
       --pprof-addr string                   Listen address for pprof endpoints. pprof is disabled by default
       --pvc-sync-annotation-keys strings    The keys of annotations from MySQLCluster's volumeClaimTemplates to be synced to the PVC
       --pvc-sync-label-keys strings         The keys of labels from MySQLCluster's volumeClaimTemplates to be synced to the PVC
-      --skip_headers                        If true, avoid header prefixes in the log messages
-      --skip_log_headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) (default 2)
       --partition-update-interval duration  The minimum update interval for partitions (e.g., 5s, 100ms) (default: 0 ms)
-  -v, --v Level                             number for the log level verbosity
+  -v, --v Level                             number for the log level verbosity (only for klog entries, e.g. from client-go). --zap-log-level needs to be raised as well to see them
       --version                             version for moco-controller
-      --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging (only for klog entries, e.g. from client-go)
       --webhook-addr string                 Listen address for the webhook endpoint (default ":9443")
       --zap-devel                           Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
       --zap-encoder encoder                 Zap log encoding (one of 'json' or 'console')

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/cybozu-go/moco-agent v0.16.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2
+	github.com/go-logr/zapr v1.3.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/go-cmp v0.7.0
 	github.com/jmoiron/sqlx v1.4.0
@@ -95,7 +96,6 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/jsonreference v0.21.5 // indirect
 	github.com/go-openapi/swag v0.25.5 // indirect

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,123 @@
+// Package log provides the logger shared by the MOCO components.
+package log
+
+import (
+	"os"
+	"slices"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zapgrpc"
+	"google.golang.org/grpc/grpclog"
+	"k8s.io/klog/v2"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// Setup creates a logger and registers it to controller-runtime, klog and gRPC,
+// then returns it. Without the redirection, client-go and gRPC write their own
+// text formats to stderr.
+func Setup(opts *crzap.Options) logr.Logger {
+	logger := newLogger(opts)
+
+	crlog.SetLogger(logger)
+
+	// Stack traces of the library entries consist of frames inside the libraries.
+	libOpts := *opts
+	libOpts.StacktraceLevel = zapcore.DPanicLevel
+	libLogger := newZap(&libOpts)
+
+	// ContextualLogger lets the libraries use the logger without going through klog.
+	klog.SetLoggerWithOptions(zapr.NewLogger(libLogger).WithName("klog"), klog.ContextualLogger(true))
+
+	// gRPC logs every connection state change at the info level. zap.IncreaseLevel
+	// is not used here because it complains when the configured level is higher.
+	grpcOpts := libOpts
+	grpcOpts.Level = zap.LevelEnablerFunc(func(l zapcore.Level) bool {
+		return l >= zapcore.WarnLevel && (opts.Level == nil || opts.Level.Enabled(l))
+	})
+	grpclog.SetLoggerV2(zapgrpc.NewLogger(newZap(&grpcOpts).Named("grpc")))
+
+	return logger
+}
+
+// newLogger is equivalent to crzap.New(crzap.UseFlagOptions(opts)) except that
+// the returned logger does not sample log entries. crzap.New drops entries when
+// the same message is logged more than 100 times a second, which happens while
+// reconciling a lot of MySQLClusters.
+// https://github.com/kubernetes-sigs/controller-runtime/blob/v0.23.3/pkg/log/zap/zap.go#L170-L243
+func newLogger(opts *crzap.Options) logr.Logger {
+	return zapr.NewLogger(newZap(opts))
+}
+
+func newZap(opts *crzap.Options) *zap.Logger {
+	o := *opts
+	o.ZapOpts = slices.Clone(opts.ZapOpts)
+	addDefaults(&o)
+
+	sink := zapcore.AddSync(o.DestWriter)
+	zapOpts := append(o.ZapOpts, zap.AddStacktrace(o.StacktraceLevel), zap.ErrorOutput(sink))
+	core := zapcore.NewCore(&crzap.KubeAwareEncoder{Encoder: o.Encoder, Verbose: o.Development}, sink, o.Level)
+
+	return zap.New(core, zapOpts...)
+}
+
+// addDefaults is a copy of the unexported crzap.Options.addDefaults.
+func addDefaults(o *crzap.Options) {
+	if o.DestWriter == nil {
+		o.DestWriter = os.Stderr
+	}
+
+	if o.Development {
+		if o.NewEncoder == nil {
+			o.NewEncoder = newConsoleEncoder
+		}
+		if o.Level == nil {
+			o.Level = zapcore.DebugLevel
+		}
+		if o.StacktraceLevel == nil {
+			o.StacktraceLevel = zapcore.WarnLevel
+		}
+		o.ZapOpts = append(o.ZapOpts, zap.Development())
+	} else {
+		if o.NewEncoder == nil {
+			o.NewEncoder = newJSONEncoder
+		}
+		if o.Level == nil {
+			o.Level = zapcore.InfoLevel
+		}
+		if o.StacktraceLevel == nil {
+			o.StacktraceLevel = zapcore.ErrorLevel
+		}
+	}
+
+	if o.TimeEncoder == nil {
+		o.TimeEncoder = zapcore.RFC3339TimeEncoder
+	}
+
+	if o.Encoder == nil {
+		// Prepended so that EncoderConfigOptions can override it.
+		encOpts := append([]crzap.EncoderConfigOption{func(ec *zapcore.EncoderConfig) {
+			ec.EncodeTime = o.TimeEncoder
+		}}, o.EncoderConfigOptions...)
+		o.Encoder = o.NewEncoder(encOpts...)
+	}
+}
+
+func newJSONEncoder(opts ...crzap.EncoderConfigOption) zapcore.Encoder {
+	encoderConfig := zap.NewProductionEncoderConfig()
+	for _, opt := range opts {
+		opt(&encoderConfig)
+	}
+	return zapcore.NewJSONEncoder(encoderConfig)
+}
+
+func newConsoleEncoder(opts ...crzap.EncoderConfigOption) zapcore.Encoder {
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+	for _, opt := range opts {
+		opt(&encoderConfig)
+	}
+	return zapcore.NewConsoleEncoder(encoderConfig)
+}


### PR DESCRIPTION
Log entries now go through `pkg/log`, which builds the zap logger without the sampler and registers
it to controller-runtime, klog and gRPC.

## Notes

- The log format and the `--zap-*` flags are unchanged: `pkg/log` keeps everything but the sampler
  identical to `crzap.New()`. `addDefaults` there is a copy of the unexported
  `crzap.Options.addDefaults`, so compare it with upstream when bumping controller-runtime.
- **Not backward compatible**: the 12 klog flags that only configure klog's own output
  (`--logtostderr`, `--log_file`, ...) are deprecated and hidden. They are still accepted but have no
  effect, so anyone who used `--log_file` to separate the client-go entries loses that.
- `-v` alone no longer shows the verbose client-go entries; `--zap-log-level` has to be raised as
  well. `-v`, `--vmodule` and `--log_backtrace_at` still work and now say so in their help text.