### PR TITLE
Fix nil pointer dereference for an offline MySQLCluster

### DIFF
--- a/clustering/process.go
+++ b/clustering/process.go
@@ -185,6 +185,15 @@ func (p *managerProcess) do(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to update status fields in MySQLCluster: %w", err)
 	}
 
+	// An offline cluster has no mysqld Pods. GatherStatus skips the Pod count
+	// check when spec.offline is true, so ss.Pods is a slice of nil pointers.
+	// Handling the prevent-delete annotation would dereference them, and the
+	// StateOffline branch below does nothing anyway, so return here.
+	if ss.State == StateOffline {
+		logFromContext(ctx).Info("cluster state is " + ss.State.String())
+		return false, nil
+	}
+
 	if ss.PreventPodDeletion {
 		err := p.addAnnPreventDelete(ctx, ss)
 		if err != nil {

--- a/clustering/process_test.go
+++ b/clustering/process_test.go
@@ -1,0 +1,94 @@
+package clustering
+
+import (
+	"context"
+	"testing"
+
+	mocov1beta2 "github.com/cybozu-go/moco/api/v1beta2"
+	"github.com/cybozu-go/moco/pkg/dbop"
+	"github.com/cybozu-go/moco/pkg/metrics"
+	"github.com/cybozu-go/moco/pkg/password"
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// nopOperatorFactory mimics the production factory for a cluster whose Pods do
+// not exist: defaultFactory.New returns a NopOperator, not an error, when the
+// instance address cannot be resolved.
+type nopOperatorFactory struct{}
+
+func (nopOperatorFactory) New(context.Context, *mocov1beta2.MySQLCluster, *password.MySQLPassword, int) (dbop.Operator, error) {
+	return dbop.NopOperator{}, nil
+}
+
+func (nopOperatorFactory) Cleanup() {}
+
+// An offline MySQLCluster has no mysqld Pods. GatherStatus skips the Pod count
+// check when spec.offline is true, so StatusSet.Pods is left as a slice of nil
+// pointers. do() must not dereference them.
+func TestDoWithOfflineClusterHavingNoPods(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	if err := mocov1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	cluster := &mocov1beta2.MySQLCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: mocov1beta2.MySQLClusterSpec{
+			Replicas: 1,
+			Offline:  true,
+		},
+	}
+
+	passwd, err := password.NewMySQLPassword()
+	if err != nil {
+		t.Fatalf("failed to generate a password: %v", err)
+	}
+	secret := passwd.ToSecret()
+	secret.Namespace = cluster.Namespace
+	secret.Name = cluster.UserSecretName()
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mocov1beta2.MySQLCluster{}).
+		WithObjects(cluster, secret).
+		Build()
+
+	if metrics.AvailableVec == nil {
+		metrics.Register(prometheus.NewRegistry())
+	}
+
+	name := types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}
+	p := newManagerProcess(c, c, record.NewFakeRecorder(10), nopOperatorFactory{}, nil, name, func() {})
+	ctx := context.Background()
+
+	ss, err := p.GatherStatus(ctx)
+	if err != nil {
+		t.Fatalf("GatherStatus returned an error: %v", err)
+	}
+	defer ss.Close()
+
+	if ss.State != StateOffline {
+		t.Errorf("expected the state to be %v, got %v", StateOffline, ss.State)
+	}
+	if len(ss.Pods) != 1 || ss.Pods[0] != nil {
+		t.Fatalf("expected Pods to hold exactly one nil entry, got %v", ss.Pods)
+	}
+
+	// Without the fix, this panics with a nil pointer dereference.
+	redo, err := p.do(ctx)
+	if err != nil {
+		t.Errorf("do returned an error: %v", err)
+	}
+	if redo {
+		t.Error("do returned redo=true for an offline cluster")
+	}
+}


### PR DESCRIPTION
We've come across an issue where an offline MySQL cluster takes down the controller due to nil deference, in our production cluster. It looks like a bug to me and I'm sending patch hereby to discuss how it can be fixed.

## Version

0.34-0.37

## Observation

Controller repeatedly goes down into crash loop with following log

```
moco-controller-6644549779-ljvjv moco-controller {"level":"error","ts":"2026-09-02T23:49:01Z","logger":"cluster-manager.(namespace)/(cluatername)","msg":"error","operationId":"op-j6fp4","duration":0.069841086,"error":"too few pods; only 0 pods exist","stacktrace":"github.com/cybozu-go/moco/clustering.(*managerProcess).Start\n\t/work/clustering/process.go:165\ngithub.com/cybozu-go/moco/clustering.(*clusterManager).update.func1\n\t/work/clustering/manager.go:94\nsync.(*WaitGroup).Go.func1\n\t/usr/local/go/src/sync/waitgroup.go:258"}

```

followed by stack trace

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb8]

github.com/cybozu-go/moco/clustering.(*managerProcess).removeAnnPreventDelete
	/work/clustering/operations.go:357
github.com/cybozu-go/moco/clustering.(*managerProcess).do
	/work/clustering/process.go:194
github.com/cybozu-go/moco/clustering.(*managerProcess).Start
	/work/clustering/process.go:160
github.com/cybozu-go/moco/clustering.(*clusterManager).update.func1
	/work/clustering/manager.go:94
```

## Description

An offline MySQLCluster has no mysqld Pods. GatherStatus skips the Pod count check when spec.offline is true, so StatusSet.Pods is left as a slice of nil pointers:

```go
    if !cluster.Spec.Offline && int(cluster.Spec.Replicas) != len(pods.Items) {
        return nil, fmt.Errorf("too few pods; only %d pods exist", len(pods.Items))
    }
    ss.Pods = make([]*corev1.Pod, cluster.Spec.Replicas)
    for i, pod := range pods.Items { ... }  // no iteration when there is no Pod
```

GatherStatus still succeeds in this case: when an instance address cannot be resolved, dbop's factory returns a NopOperator rather than an error, and GetStatus then reports ErrNop, which the status loop treats as "no status" instead of a failure.

do() handles the prevent-delete annotation before the ss.State switch, so removeAnnPreventDelete dereferences one of those nil Pods and panics. The panic happens in a goroutine started by clusterManager.update, so it is not recovered and the whole moco-controller process crashes. A single offline MySQLCluster therefore takes down the controller for every MySQLCluster it manages.

Return early from do() when the cluster is offline. The switch below already handles StateOffline by returning (false, nil), so this only moves the check ahead of the code that cannot handle nil Pods.